### PR TITLE
Move product images to services section

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -196,25 +196,41 @@ footer{
 .social-icons{display:flex;gap:1rem;justify-content:center;}
 .social-icons a i{font-size:1.5rem;}
 
+
 .footer-copy{
   text-align:center;
   border-top:1px solid rgba(255,255,255,.2);
   padding-top:.5rem;
 }
 
-/* ---- About Images ---- */
-.about-images{
+/* ---- Service Images ---- */
+.service-images {
   display:flex;
   justify-content:center;
-  gap:1rem;
-  margin-top:1.5rem;
+  gap:2rem;
+  margin-bottom:2rem;
 }
-.about-images img{
-  width:100px;
-  height:auto;
-  border-radius:8px;
+.service-images img {
+  width:140px;
+  height:140px;
   object-fit:cover;
+  border-radius:18px;
+  box-shadow:0 4px 12px rgba(0,0,0,0.08);
+  transition:transform 0.2s;
 }
+.service-images img:hover {
+  transform:scale(1.07);
+  box-shadow:0 8px 24px rgba(0,0,0,0.12);
+}
+
+@media (max-width:768px) {
+  .service-images {
+    flex-direction:column;
+    align-items:center;
+    gap:1rem;
+  }
+}
+
 
 /* ---- Why Us ---- */
 #why-us .why-us-items{
@@ -243,6 +259,5 @@ footer{
 /* ========= RESPONSIVE ========= */
 @media(max-width:600px){
   #hero h1{font-size:1.6rem}
-  .about-images{flex-direction:column}
   .top-bar{flex-direction:column;text-align:center}
 }

--- a/index.html
+++ b/index.html
@@ -49,6 +49,11 @@
   <!-- ===== Services ===== -->
   <section id="services">
     <h2>خدمات ما</h2>
+    <div class="service-images">
+      <img src="images/generator.png" alt="دیزل ژنراتور" />
+      <img src="images/solar.png" alt="پنل خورشیدی" />
+      <img src="images/battery.png" alt="باتری صنعتی" />
+    </div>
       <div class="service-grid">
         <article class="service-card">
           <i class="icon fa-solid fa-lightbulb"></i>
@@ -173,11 +178,6 @@
       تا با تکیه بر راهکارهای نوین، پایداری شبکهٔ برق داخلی خود را تضمین کرده و
       از خسارات ناشی از قطعی جلوگیری کنند.
     </p>
-    <div class="about-images">
-      <img src="images/generator.png" alt="دیزل ژنراتور" />
-      <img src="images/solar.png" alt="پنل خورشیدی" />
-      <img src="images/battery.png" alt="باتری صنعتی" />
-    </div>
   </section>
 
   <!-- ===== Contact ===== -->


### PR DESCRIPTION
## Summary
- display equipment images at the beginning of the services section
- remove old About section gallery
- style service images with flexbox, hover effects and responsive layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877f9417e6c8328a89f9f97c935a091