### PR TITLE
Improve service image gallery

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -205,29 +205,37 @@ footer{
 
 /* ---- Service Images ---- */
 .service-images {
-  display:flex;
-  justify-content:center;
-  gap:2rem;
-  margin-bottom:2rem;
-}
-.service-images img {
-  width:140px;
-  height:140px;
-  object-fit:cover;
-  border-radius:18px;
-  box-shadow:0 4px 12px rgba(0,0,0,0.08);
-  transition:transform 0.2s;
-}
-.service-images img:hover {
-  transform:scale(1.07);
-  box-shadow:0 8px 24px rgba(0,0,0,0.12);
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1.5rem;
+  margin: 2rem 0;
 }
 
-@media (max-width:768px) {
-  .service-images {
-    flex-direction:column;
-    align-items:center;
-    gap:1rem;
+.image-card {
+  flex: 0 0 calc(33.33% - 1.5rem);
+  max-width: calc(33.33% - 1.5rem);
+  text-align: center;
+}
+
+.image-card img {
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+  transition: transform 0.3s, box-shadow 0.3s;
+}
+
+.image-card img:hover {
+  transform: scale(1.05);
+  box-shadow: 0 8px 24px rgba(0,0,0,0.15);
+}
+
+@media (max-width: 768px) {
+  .image-card {
+    flex: 0 0 100%;
+    max-width: 100%;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -50,9 +50,15 @@
   <section id="services">
     <h2>خدمات ما</h2>
     <div class="service-images">
-      <img src="images/generator.png" alt="دیزل ژنراتور" />
-      <img src="images/solar.png" alt="پنل خورشیدی" />
-      <img src="images/battery.png" alt="باتری صنعتی" />
+      <div class="image-card">
+        <img src="images/generator.png" alt="ژنراتور دیزل" />
+      </div>
+      <div class="image-card">
+        <img src="images/solar.png" alt="پنل خورشیدی" />
+      </div>
+      <div class="image-card">
+        <img src="images/battery.png" alt="باتری صنعتی" />
+      </div>
     </div>
       <div class="service-grid">
         <article class="service-card">


### PR DESCRIPTION
## Summary
- wrap service images in `.image-card` containers and adjust alt text
- revamp image gallery styling for responsive three-column layout

## Testing
- `npm test` *(fails: `ENOENT` no `package.json`)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6877fb118d9c8328b5e3fcfbf074ee20