### PR TITLE
Add decision tree button styles

### DIFF
--- a/decision-tree-rtl-app/src/components/DecisionTree.js
+++ b/decision-tree-rtl-app/src/components/DecisionTree.js
@@ -107,7 +107,8 @@ const DecisionTree = () => {
                     />
                   </div>
                   <button className="decision-btn" onClick={handleCalc}>
-                    محاسبه
+                    <span>محاسبه</span>
+                    <span className="arrow">←</span>
                   </button>
                 </div>
               )}
@@ -123,7 +124,8 @@ const DecisionTree = () => {
                         className="decision-btn"
                         onClick={() => handleOption(opt.next)}
                       >
-                        {opt.label}
+                        <span>{opt.label}</span>
+                        <span className="arrow">←</span>
                       </button>
                     ))}
                 </div>
@@ -140,7 +142,8 @@ const DecisionTree = () => {
                   className="decision-btn"
                   onClick={() => handleOption(opt.next)}
                 >
-                  {opt.label}
+                  <span>{opt.label}</span>
+                  <span className="arrow">←</span>
                 </button>
               ))}
             </div>

--- a/decision-tree-rtl-app/src/index.css
+++ b/decision-tree-rtl-app/src/index.css
@@ -19,6 +19,7 @@ body {
 
 /* Decision tree option buttons */
 .decision-btn {
+  width: 80%;
   padding: 0.8rem 2.5rem;
   border-radius: 8px;
   font-weight: bold;
@@ -28,11 +29,13 @@ body {
   color: #fff;
   border: none;
   cursor: pointer;
-  transition: background 0.2s;
-  width: 80%;
   margin-bottom: 1rem;
-  outline: none;
   font-family: inherit;
+  transition: background 0.2s;
+  direction: rtl;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .decision-btn:focus {
@@ -43,8 +46,8 @@ body {
   background-color: #159b39;
 }
 
-.decision-btn::after {
-  content: "\2190"; /* left arrow */
-  margin-left: 0.5rem;
+.decision-btn .arrow {
+  font-size: 1.5rem;
+  margin-right: 1rem;
 }
 

--- a/decision-tree/src/components/DecisionTree.jsx
+++ b/decision-tree/src/components/DecisionTree.jsx
@@ -18,10 +18,11 @@ export default function DecisionTree() {
           {node.options.map((opt, idx) => (
             <button
               key={idx}
-              className="px-4 py-2 rounded bg-green-600 text-white"
+              className="decision-btn"
               onClick={() => handleChoice(idx)}
             >
-              {opt}
+              <span>{opt}</span>
+              <span className="arrow">←</span>
             </button>
           ))}
         </div>

--- a/decision-tree/src/index.css
+++ b/decision-tree/src/index.css
@@ -2,3 +2,37 @@
 body {
   font-family: 'Vazirmatn', sans-serif;
 }
+
+/* Decision tree option buttons */
+.decision-btn {
+  width: 80%;
+  padding: 0.8rem 2.5rem;
+  border-radius: 8px;
+  font-weight: bold;
+  font-size: 1.2rem;
+  text-align: right;
+  background-color: #1db446;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  margin-bottom: 1rem;
+  font-family: inherit;
+  transition: background 0.2s;
+  direction: rtl;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.decision-btn:focus {
+  outline: none;
+}
+
+.decision-btn:hover {
+  background-color: #159b39;
+}
+
+.decision-btn .arrow {
+  font-size: 1.5rem;
+  margin-right: 1rem;
+}


### PR DESCRIPTION
## Summary
- ensure decision tree option buttons share `.decision-btn` class
- style decision tree buttons with new `.decision-btn` CSS
- add arrow span to option buttons

## Testing
- `CI=true npm test --silent` (fails: No tests found)
- `npm run test` in decision-tree (fails: missing script)

------
https://chatgpt.com/codex/tasks/task_e_687cfb153b908328b9c4c35007a82090