### PR TITLE
Apply sitewide RTL and color palette

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,17 +1,19 @@
 /* ========= Root & Reset ========= */
 :root{
-  --dark-blue:#003865;  /* از دایرهٔ بیرونی لوگو */
-  --green:#006c53;      /* بخش سبز لوگو */
+  --primary:#20603d;    /* سبز تیره */
+  --dark-blue:#20603d;  /* هماهنگ با پالت جدید */
+  --green:#20603d;      /* رنگ اصلی */
   --yellow:#ffd500;     /* صاعقه */
-  --gray:#f7f8fa;
+  --gray:#f0f0f0;       /* طوسی روشن */
 }
 *{box-sizing:border-box;margin:0;padding:0}
 
 body{
-  font-family:'Vazirmatn',sans-serif;
+  font-family:'Vazirmatn','IranSans',sans-serif;
   line-height:1.7;
   background:#fff;
-  color:#222;
+  color:#333;
+  direction:rtl;
 }
 
 /* ========= Top Bar ========= */
@@ -23,7 +25,7 @@ body{
   display:flex;
   justify-content:space-between;
   align-items:center;
-  direction:ltr;
+  direction:rtl;
 }
 .top-bar span{
   display:flex;
@@ -48,7 +50,7 @@ body{
 .nav-menu a{
   text-decoration:none;
   color:var(--dark-blue);
-  font-family:'Vazirmatn',sans-serif;
+  font-family:'Vazirmatn','IranSans',sans-serif;
 }
 .menu-toggle{display:none}
 .hamburger{display:none;cursor:pointer;width:30px;height:24px;position:relative}

--- a/decision-tree-rtl-app/src/components/DecisionTree.js
+++ b/decision-tree-rtl-app/src/components/DecisionTree.js
@@ -16,7 +16,7 @@ const buttonStyle = {
   border: 'none',
   borderRadius: '6px',
   fontSize: '1rem',
-  backgroundColor: '#10b981',
+  backgroundColor: '#20603d',
   color: '#fff',
   cursor: 'pointer',
 };

--- a/decision-tree-rtl-app/src/index.css
+++ b/decision-tree-rtl-app/src/index.css
@@ -25,7 +25,7 @@ body {
   font-weight: bold;
   font-size: 1.2rem;
   text-align: right;
-  background-color: #1db446;
+  background-color: #20603d;
   color: #fff;
   border: none;
   cursor: pointer;
@@ -43,7 +43,7 @@ body {
 }
 
 .decision-btn:hover {
-  background-color: #159b39;
+  background-color: #184d2d;
 }
 
 .decision-btn .arrow {

--- a/decision-tree/index.html
+++ b/decision-tree/index.html
@@ -7,7 +7,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Vazirmatn:wght@400;700&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
   </head>
-  <body class="bg-gray-100 font-sans" style="font-family: 'Vazirmatn', sans-serif;">
+  <body class="bg-gray-100 font-sans" style="font-family: 'Vazirmatn','IranSans', sans-serif;">
     <div id="root" class="p-4"></div>
     <script type="module" src="/src/index.jsx"></script>
   </body>

--- a/decision-tree/src/index.css
+++ b/decision-tree/src/index.css
@@ -1,6 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Vazirmatn:wght@400;700&display=swap');
 body {
-  font-family: 'Vazirmatn', sans-serif;
+  font-family: 'Vazirmatn','IranSans', sans-serif;
 }
 
 /* Decision tree option buttons */
@@ -11,7 +11,7 @@ body {
   font-weight: bold;
   font-size: 1.2rem;
   text-align: right;
-  background-color: #1db446;
+  background-color: #20603d;
   color: #fff;
   border: none;
   cursor: pointer;
@@ -29,7 +29,7 @@ body {
 }
 
 .decision-btn:hover {
-  background-color: #159b39;
+  background-color: #184d2d;
 }
 
 .decision-btn .arrow {

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
       <span class="hours"><i class="fa fa-clock"></i> 8:00-18:00</span>
     </div>
 
-    <div class="sticky-header" dir="ltr">
+    <div class="sticky-header">
       <a href="index.html" class="header-logo">
         <img src="images/logo.png" alt="Parsana Energy logo" />
       </a>


### PR DESCRIPTION
## Summary
- unify colors around #20603d
- enforce RTL layout and Vazirmatn/IranSans fonts
- tweak decision tree styles to use new primary color

## Testing
- `npm run build` in decision-tree
- `npm run build` in decision-tree-rtl-app

------
https://chatgpt.com/codex/tasks/task_e_687d01cffc448328bb45b42854d5f453