### PR TITLE
Fix SRI for FontAwesome CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
   <!-- Google Font (Vazirmatn لاتین + فارسی) -->
   <link href="https://fonts.googleapis.com/css2?family=Vazirmatn:wght@300;400;700&display=swap" rel="stylesheet">
 
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" integrity="sha512-Mr+fVJQ+zb3TrIVXPYlKAG+XZX9L0NVr7DiIP9N6byN1Nsx3Rp3XIan+FJxuxMxDPZWS9Vyhi3F7S3w7r3r8jw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" integrity="sha512-z3gLpd7yknf1YoNbCzqRKc4qyor8gaKU1qmn+CShxbuBusANI9QpRohGBreCFkKxLhei6S9CQXFEbbKuqLg0DA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="css/style.css" />
   <link rel="stylesheet" href="decision-tree/dist/assets/index-866bb4fd.css" />
 </head>


### PR DESCRIPTION
## Summary
- update FontAwesome integrity hash in the main `index.html`

## Testing
- `npm run lint` in `decision-tree-app`
- `CI=true npm test -- --passWithNoTests` in `decision-tree-rtl-app`

------
https://chatgpt.com/codex/tasks/task_e_687da831c1388328ac3590a30d8f56f2