### PR TITLE
Fix duplicate header

### DIFF
--- a/decision-tree-app/src/App.jsx
+++ b/decision-tree-app/src/App.jsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import './index.css';
-import Header from './components/Header.jsx';
 import DecisionTree from './components/DecisionTree.jsx';
 
 export default function App() {
   return (
     <div className="App">
-      <Header />
       <main>
         <h1>درخت تصمیم مشتری</h1>
         <DecisionTree />


### PR DESCRIPTION
## Summary
- remove `Header` from the React decision tree app

## Testing
- `npm run lint` in `decision-tree-app`
- `npm run build` in `decision-tree-app`


------
https://chatgpt.com/codex/tasks/task_e_687e3c3993a48328913b8bf23ed7946f