### PR TITLE
Remove duplicate header from decision tree

### DIFF
--- a/decision-tree-rtl-app/src/App.js
+++ b/decision-tree-rtl-app/src/App.js
@@ -1,12 +1,10 @@
 import React from 'react';
 import './index.css';
-import Header from './components/Header';
 import DecisionTree from './components/DecisionTree';
 
 function App() {
   return (
     <div className="App">
-      <Header />
       <main>
         <h1>درخت تصمیم مشتری</h1>
         <DecisionTree />


### PR DESCRIPTION
## Summary
- remove unused Header component from decision-tree-rtl-app

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687e43f3edd883289285708232e76560