### PR TITLE
Fix articles navigation routing

### DIFF
--- a/decision-tree-app/src/App.jsx
+++ b/decision-tree-app/src/App.jsx
@@ -14,6 +14,8 @@ export default function App() {
         <Route path="/" element={<Home />} />
         <Route path="/articles" element={<Articles />} />
         <Route path="/articles/:slug" element={<Article />} />
+        <Route path="/blog" element={<Articles />} />
+        <Route path="/blog/:slug" element={<Article />} />
       </Routes>
     </div>
   );

--- a/docs/index.html
+++ b/docs/index.html
@@ -41,7 +41,7 @@
           <li><a href="index.html">خانه</a></li>
           <li><a href="#services">خدمات</a></li>
           <li><a href="#projects">پروژه‌ها</a></li>
-          <li><a href="#blog">بلاگ</a></li>
+          <li><a href="/parsanaenergy/articles">بلاگ</a></li>
           <li><a href="#contact">تماس با ما</a></li>
         </ul>
       </nav>
@@ -215,7 +215,7 @@
           <li><a href="index.html">خانه</a></li>
           <li><a href="#services">خدمات</a></li>
           <li><a href="#projects">پروژه‌ها</a></li>
-          <li><a href="#blog">بلاگ</a></li>
+          <li><a href="/parsanaenergy/articles">بلاگ</a></li>
           <li><a href="#contact">تماس با ما</a></li>
         </ul>
       </div>


### PR DESCRIPTION
## Summary
- update blog link in the static site to point to the React app
- support `/blog` path in the React router

## Testing
- `npm run lint` in `decision-tree-app`
- `npm run build` in `docs`

------
https://chatgpt.com/codex/tasks/task_e_687fad1e357c8328946ae1e950d6ba6f