### PR TITLE
Unify decision tree button styles

### DIFF
--- a/decision-tree-app/src/components/DecisionTree.jsx
+++ b/decision-tree-app/src/components/DecisionTree.jsx
@@ -9,22 +9,6 @@ const containerStyle = {
   boxSizing: 'border-box',
 };
 
-const buttonStyle = {
-  width: '100%',
-  padding: '0.75rem',
-  marginBottom: '0.75rem',
-  border: 'none',
-  borderRadius: '6px',
-  fontSize: '1rem',
-  backgroundColor: '#20603d',
-  color: '#fff',
-  cursor: 'pointer',
-};
-
-const backButtonStyle = {
-  ...buttonStyle,
-  backgroundColor: '#6c757d',
-};
 
 const inputStyle = {
   width: '100%',
@@ -151,7 +135,7 @@ const DecisionTree = () => {
 
           {/* Back Button */}
           <button
-            style={backButtonStyle}
+            className="decision-btn"
             onClick={handleBack}
             disabled={history.length === 1 && calcResult === null}
           >

--- a/decision-tree-app/src/index.css
+++ b/decision-tree-app/src/index.css
@@ -1,1 +1,32 @@
 /* Decision Tree App styles */
+
+.decision-btn {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 8px 28px;
+  margin-top: 16px;
+  background-color: #2D6A4F;
+  color: #FFFFFF;
+  font-size: 15px;
+  font-weight: bold;
+  line-height: 1.6;
+  border: none;
+  border-radius: 9999px;
+  cursor: pointer;
+  box-shadow: 0 2px 6px #0001;
+  transition: background-color 0.3s;
+  outline: none;
+}
+
+.decision-btn:hover {
+  background-color: #214F3B;
+}
+
+.decision-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+


### PR DESCRIPTION
## Summary
- redesign decision tree buttons with capsule look
- reuse the same class for the back button

## Testing
- `npm run lint` in `decision-tree-app`
- `npm run build` in `decision-tree-app`
- `npm install` and `npm run build` in `docs`

------
https://chatgpt.com/codex/tasks/task_e_68823f5d2b1c8328b5c0e44166807176