### PR TITLE
Add widget build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ npm install
 npm run dev        # development server
 npm run build      # build to dist/
 npm run preview    # preview production build
+npm run build-widget # build and copy into docs/widget
 ```
 
 ## Repository layout

--- a/decision-tree-app/README.md
+++ b/decision-tree-app/README.md
@@ -15,4 +15,5 @@ npm run dev           # start development server
 npm run build         # build to dist/
 npm run preview       # preview the built app
 npm run deploy        # build and publish to GitHub Pages
+npm run build-widget  # build and copy files to ../docs/widget
 ```

--- a/decision-tree-app/build-widget.sh
+++ b/decision-tree-app/build-widget.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Build the decision-tree-app and copy the output to docs/widget
+# Uses npmjs.org registry, falling back to npmmirror.com if needed.
+
+set -e
+
+npm config set registry https://registry.npmjs.org/
+npm ci --legacy-peer-deps || npm install --legacy-peer-deps
+if [ $? -ne 0 ]; then
+  npm config set registry https://registry.npmmirror.com/
+  npm ci --legacy-peer-deps || npm install --legacy-peer-deps
+fi
+
+if [ $? -ne 0 ]; then
+  echo "❌ وابستگی‌ها نصب نشدند (حتی با legacy-peer-deps). راه‌حل: نسخه vite یا پلاگین را اصلاح کن."
+  exit 1
+fi
+
+npm run build
+mkdir -p ../docs/widget
+cp -r dist/* ../docs/widget/
+
+echo "✅ نصب و build با موفقیت انجام شد، فایل‌ها به docs/widget منتقل شدند."

--- a/decision-tree-app/package.json
+++ b/decision-tree-app/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build-widget": "bash build-widget.sh",
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "npm run build",


### PR DESCRIPTION
## Summary
- create build-widget.sh to install dependencies and copy the build
- expose `npm run build-widget` script for decision-tree-app
- document widget build in decision-tree-app/README
- mention build-widget command in root README

## Testing
- `npm run lint`
- `npm run build` in docs

------
https://chatgpt.com/codex/tasks/task_e_688362ddc9ec83288dfd3f526cdbc9a5