### PR TITLE
Fix blog path by redirecting to articles

### DIFF
--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+  <meta charset="utf-8" />
+  <title>مقالات پارسانا انرژی</title>
+  <link rel="stylesheet" href="../css/style.css" />
+</head>
+<body>
+  <main class="articles-list">
+    <h1>مقالات تخصصی</h1>
+    <ul>
+      <li class="article-item">
+        <a href="monthly-generator-pm-checklist.html">چک لیست سرویس ماهانه ژنراتور</a>
+      </li>
+    </ul>
+    <p><a href="../index.html">بازگشت به صفحه اصلی</a></p>
+  </main>
+</body>
+</html>

--- a/docs/articles/monthly-generator-pm-checklist.html
+++ b/docs/articles/monthly-generator-pm-checklist.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+  <meta charset="utf-8" />
+  <title>چک لیست سرویس ماهانه ژنراتور</title>
+  <link rel="stylesheet" href="../css/style.css" />
+</head>
+<body>
+  <main class="article-detail">
+    <h1>چک لیست سرویس ماهانه ژنراتور</h1>
+    <p>در این مقاله به مواردی که باید در سرویس ماهانه ژنراتورها بررسی شود می‌پردازیم.</p>
+    <ol>
+      <li>بررسی سطح روغن و فیلترها</li>
+      <li>چک کردن اتصالات و کابل‌ها</li>
+      <li>تست عملکرد بدون بار</li>
+    </ol>
+    <p>امیدواریم این راهنما به نگهداری بهتر ژنراتور شما کمک کند.</p>
+    <p><a href="index.html">بازگشت به مقالات</a></p>
+  </main>
+</body>
+</html>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script>
+      window.location.href = "/parsanaenergy/docs/articles/";
+    </script>
+    <title>Redirecting...</title>
+  </head>
+  <body>
+    در حال انتقال به مقالات…
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add static article HTML files
- add blog index page that redirects to the articles

## Testing
- `npm run build` in `docs`
- `npm install --legacy-peer-deps` and `npm run lint` in `decision-tree-app`


------
https://chatgpt.com/codex/tasks/task_e_688366bb03e083289bd89221cd8cb0e5