### PR TITLE
Fix widget path in main site

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -102,11 +102,11 @@
     <h2>اپلیکیشن درخت تصمیم</h2>
     <div id="decision-tree-app-container"></div>
     <script>
-      fetch('docs/widget/index.html', { method: 'HEAD' })
+      fetch('widget/index.html', { method: 'HEAD' })
         .then(function (response) {
           if (response.ok) {
             var iframe = document.createElement('iframe');
-            iframe.src = 'docs/widget/index.html';
+            iframe.src = 'widget/index.html';
             iframe.width = '100%';
             iframe.height = '600';
             iframe.style.border = 'none';


### PR DESCRIPTION
## Summary
- use correct relative path for Decision Tree widget

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68836b75bf688328928033345ace2fc5