### PR TITLE
Add responsive services catalog page

### DIFF
--- a/docs/assets/services-style.css
+++ b/docs/assets/services-style.css
@@ -1,0 +1,112 @@
+.services-catalog {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 1rem;
+  font-family: 'Vazirmatn', sans-serif;
+}
+.catalog-header {
+  background: var(--green);
+  color: #fff;
+  text-align: center;
+  padding: 1rem;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+}
+.catalog-header img {
+  width: 40px;
+  height: 40px;
+}
+.catalog-header h1 {
+  font-size: 1.2rem;
+  margin: 0;
+}
+.categories-list {
+  display: flex;
+  gap: 1rem;
+  overflow-x: auto;
+  padding: 1rem 0;
+}
+.category-card {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  text-align: center;
+  min-width: 180px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.category-card img {
+  width: 100%;
+  height: 120px;
+  object-fit: cover;
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+}
+.category-card span {
+  display: block;
+  padding: 0.5rem;
+  font-weight: bold;
+  color: var(--dark-blue);
+}
+.services-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1rem;
+  padding: 1rem 0;
+}
+.service-card {
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  text-align: center;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.service-card img {
+  width: 80px;
+  height: 80px;
+  object-fit: cover;
+  border-radius: 50%;
+  margin-bottom: 0.5rem;
+}
+.service-card h2 {
+  font-size: 1rem;
+  margin: 0.5rem 0;
+  color: var(--dark-blue);
+}
+.service-card p {
+  font-size: 0.9rem;
+  margin-bottom: 0.5rem;
+}
+.contact-btn, .back-btn {
+  background: var(--green);
+  color: #fff;
+  border: none;
+  border-radius: 1rem;
+  padding: 0.5rem 1rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+}
+.back-btn {
+  background: var(--gray);
+  color: var(--dark-blue);
+  margin-bottom: 0.5rem;
+}
+.hidden { display: none; }
+@media (min-width: 600px) {
+  .categories-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    overflow: visible;
+  }
+  .category-card { min-width: auto; }
+}

--- a/docs/js/services.js
+++ b/docs/js/services.js
@@ -1,0 +1,25 @@
+(function(){
+  const categories = document.querySelectorAll('.category-card');
+  const categoriesList = document.querySelector('.categories-list');
+  const servicesList = document.querySelector('.services-list');
+  const backBtn = document.querySelector('.back-btn');
+
+  function showServices(catId){
+    categoriesList.classList.add('hidden');
+    servicesList.classList.remove('hidden');
+    servicesList.querySelectorAll('.service-card').forEach(card => {
+      card.style.display = card.dataset.category === catId ? 'flex' : 'none';
+    });
+  }
+
+  categories.forEach(cat => {
+    cat.addEventListener('click', () => showServices(cat.dataset.category));
+  });
+
+  if(backBtn){
+    backBtn.addEventListener('click', () => {
+      servicesList.classList.add('hidden');
+      categoriesList.classList.remove('hidden');
+    });
+  }
+})();

--- a/docs/services/index.html
+++ b/docs/services/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>کاتالوگ خدمات - پارسانا انرژی</title>
+  <link href="https://fonts.googleapis.com/css2?family=Vazirmatn:wght@300;400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" integrity="sha512-z3gLpd7yknf1YoNbCzqRKc4qyor8gaKU1qmn+CShxbuBusANI9QpRohGBreCFkKxLhei6S9CQXFEbbKuqLg0DA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="../css/style.css" />
+  <link rel="stylesheet" href="../assets/services-style.css" />
+</head>
+<body>
+  <div class="services-catalog">
+    <header class="catalog-header">
+      <img src="../images/logo.png" alt="لوگو" class="catalog-logo" />
+      <h1>کاتالوگ خدمات</h1>
+    </header>
+    <section class="categories-list">
+      <div class="category-card" data-category="maint">
+        <img src="../images/generator.png" alt="سرویس ژنراتور" />
+        <span>سرویس ژنراتور</span>
+      </div>
+      <div class="category-card" data-category="solar">
+        <img src="../images/solar.png" alt="نیروگاه خورشیدی" />
+        <span>نیروگاه خورشیدی</span>
+      </div>
+      <div class="category-card" data-category="battery">
+        <img src="../images/battery.png" alt="باتری" />
+        <span>باتری صنعتی</span>
+      </div>
+    </section>
+    <section class="services-list hidden">
+      <button class="back-btn">بازگشت</button>
+      <div class="service-card" data-category="maint">
+        <img src="../images/generator-maintenance-check.png" alt="تعویض فیلتر" />
+        <h2>تعویض فیلتر ژنراتور</h2>
+        <p>تعویض دوره‌ای انواع فیلتر جهت عملکرد بهینه.</p>
+        <button class="contact-btn">درخواست مشاوره</button>
+      </div>
+      <div class="service-card" data-category="maint">
+        <img src="../images/oil-analysis-generator.png" alt="آنالیز روغن" />
+        <h2>آنالیز روغن ژنراتور</h2>
+        <p>بررسی کیفیت روغن و ارائه گزارش تخصصی.</p>
+        <button class="contact-btn">درخواست مشاوره</button>
+      </div>
+      <div class="service-card" data-category="solar">
+        <img src="../images/solar.png" alt="طراحی نیروگاه" />
+        <h2>طراحی نیروگاه خورشیدی</h2>
+        <p>محاسبه و طراحی سیستم خورشیدی متناسب با نیاز شما.</p>
+        <button class="contact-btn">درخواست مشاوره</button>
+      </div>
+      <div class="service-card" data-category="battery">
+        <img src="../images/battery.png" alt="نصب باتری" />
+        <h2>نصب و تست باتری</h2>
+        <p>راه‌اندازی و سرویس کامل انواع باتری صنعتی.</p>
+        <button class="contact-btn">درخواست مشاوره</button>
+      </div>
+    </section>
+  </div>
+  <script src="../js/services.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add responsive services catalog under `docs/services`
- style the catalog with a mobile-first design
- add simple JS to switch between categories and service cards

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6883731e0e1c8328972b0dff3018c65e