### PR TITLE
Fix widget iframe path and build output

### DIFF
--- a/decision-tree-app/build-widget.sh
+++ b/decision-tree-app/build-widget.sh
@@ -19,11 +19,13 @@ fi
 
 npm run build
 # Copy widget build to docs/widget and also place assets under docs/assets
-mkdir -p ../docs/widget ../docs/assets
-cp -r dist/* ../docs/widget/
-cp -r dist/assets/* ../docs/assets/
 
-# Update index.html paths to use docs/assets relative URLs
-sed -i 's|/parsanaenergy/assets/|../assets/|g' ../docs/widget/index.html
+# Copy the entire dist folder to docs/widget so that index.html and
+# its hashed assets live together under docs/widget/assets
+mkdir -p ../docs/widget
+cp -r dist/* ../docs/widget/
+
+# Update index.html asset paths to use the local assets folder
+sed -i 's|/parsanaenergy/assets/|assets/|g' ../docs/widget/index.html
 
 echo "✅ نصب و build با موفقیت انجام شد، فایل‌ها به docs/widget منتقل شدند."

--- a/docs/index.html
+++ b/docs/index.html
@@ -104,11 +104,11 @@
     <h2>اپلیکیشن درخت تصمیم</h2>
     <div id="decision-tree-app-container"></div>
     <script>
-      fetch('/parsanaenergy/widget/index.html', { method: 'HEAD' })
+      fetch('widget/index.html', { method: 'HEAD' })
         .then(function (response) {
           if (response.ok) {
             var iframe = document.createElement('iframe');
-            iframe.src = '/parsanaenergy/widget/index.html';
+            iframe.src = 'widget/index.html';
             iframe.width = '100%';
             iframe.height = '600';
             iframe.style.border = 'none';

--- a/docs/widget/index.html
+++ b/docs/widget/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Decision Tree App</title>
-    <script type="module" crossorigin src="../assets/index-DL91WKal.js"></script>
-    <link rel="stylesheet" crossorigin href="../assets/index-B-e6zC8L.css">
+    <script type="module" crossorigin src="assets/index-DL91WKal.js"></script>
+    <link rel="stylesheet" crossorigin href="assets/index-B-e6zC8L.css">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- update widget iframe path in docs
- copy dist output to docs/widget with local asset paths

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688376cb6a188328bf1a6643e6448004