### PR TITLE
Add catalog viewer and 404 page

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>صفحه مورد نظر یافت نشد</title>
+  <link href="https://fonts.googleapis.com/css2?family=Vazirmatn:wght@300;400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" integrity="sha512-z3gLpd7yknf1YoNbCzqRKc4qyor8gaKU1qmn+CShxbuBusANI9QpRohGBreCFkKxLhei6S9CQXFEbbKuqLg0DA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="css/style.css" />
+</head>
+<body>
+  <div class="top-bar">
+    <span class="phone"><i class="fa fa-phone"></i> تماس :۰۹۱۵۰۱۰۰۶۳۳ </span>
+    <span class="email"><i class="fa fa-envelope"></i> info@parsana-energy.ir</span>
+    <span class="hours"><i class="fa fa-clock"></i> 8:00-18:00</span>
+  </div>
+  <div class="sticky-header">
+    <a href="index.html" class="header-logo">
+      <img src="images/logo.png" alt="Parsana Energy logo" />
+    </a>
+    <nav>
+      <ul class="nav-menu">
+        <li><a href="index.html">خانه</a></li>
+        <li><a href="index.html#services">خدمات</a></li>
+        <li><a href="articles/">بلاگ</a></li>
+        <li><a href="index.html#contact">تماس با ما</a></li>
+      </ul>
+    </nav>
+  </div>
+  <main class="not-found">
+    <h1>404</h1>
+    <p>محتوایی یافت نشد.</p>
+    <a class="btn-primary" href="index.html">بازگشت به صفحه اصلی</a>
+  </main>
+</body>
+</html>

--- a/docs/assets/services-style.css
+++ b/docs/assets/services-style.css
@@ -86,6 +86,13 @@
   font-size: 0.9rem;
   margin-bottom: 0.5rem;
 }
+.catalog-link {
+  text-align: center;
+  margin: 1rem 0;
+}
+.catalog-link a {
+  text-decoration: none;
+}
 .contact-btn, .back-btn {
   background: var(--green);
   color: #fff;

--- a/docs/catalog.html
+++ b/docs/catalog.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>کاتالوگ پارسانا انرژی</title>
+  <link href="https://fonts.googleapis.com/css2?family=Vazirmatn:wght@300;400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" integrity="sha512-z3gLpd7yknf1YoNbCzqRKc4qyor8gaKU1qmn+CShxbuBusANI9QpRohGBreCFkKxLhei6S9CQXFEbbKuqLg0DA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="css/style.css" />
+  <link rel="stylesheet" href="assets/services-style.css" />
+</head>
+<body>
+  <div class="services-catalog">
+    <header class="catalog-header">
+      <img src="images/logo.png" alt="لوگو" class="catalog-logo" />
+      <h1>کاتالوگ پارسانا انرژی</h1>
+    </header>
+    <main class="catalog-viewer">
+      <object data="catalog-resize.pdf" type="application/pdf" width="100%" height="600">
+        <p>کاتالوگ قابل نمایش نیست. <a href="catalog-resize.pdf" download>دانلود کاتالوگ</a></p>
+      </object>
+    </main>
+  </div>
+</body>
+</html>

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -449,3 +449,16 @@ footer{
   gap: .3rem;
 }
 
+/* ========= 404 Page ========= */
+.not-found {
+  text-align: center;
+  padding: 4rem 1rem;
+}
+.not-found h1 {
+  font-size: 4rem;
+  margin-bottom: 1rem;
+}
+.not-found p {
+  margin-bottom: 1rem;
+}
+

--- a/docs/services/index.html
+++ b/docs/services/index.html
@@ -15,6 +15,10 @@
       <img src="../images/logo.png" alt="لوگو" class="catalog-logo" />
       <h1>کاتالوگ خدمات</h1>
     </header>
+    <section class="catalog-link">
+      <!-- لینک به صفحه نمایش یا دانلود کاتالوگ -->
+      <a class="contact-btn" href="../catalog.html">مشاهده کاتالوگ PDF</a>
+    </section>
     <section class="categories-list">
       <div class="category-card" data-category="maint">
         <img src="../images/generator.png" alt="سرویس ژنراتور" />


### PR DESCRIPTION
## Summary
- link Services page to new Catalog page
- style catalog link
- add Catalog page embedding the PDF
- provide custom 404 page
- style not-found page

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68838952e5688328bf1f17f791e1d005