### PR TITLE
Fix decision tree widget build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,16 +18,25 @@ jobs:
           node-version: 18
           cache: 'npm'
 
-      - name: Install dependencies
-        run: npm ci
+      - name: Build decision tree widget
+        working-directory: decision-tree-app
+        run: |
+          npm ci --legacy-peer-deps
+          npm run build
+          rm -rf ../docs/widget/*
+          mkdir -p ../docs/widget
+          cp -r dist/* ../docs/widget/
 
-      - name: Build
-        run: npm run build
+      - name: Build docs site
+        working-directory: docs
+        run: |
+          npm ci
+          npm run build
 
       - name: Deploy to gh-pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
+          publish_dir: docs/dist
           publish_branch: gh-pages
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ npm run preview    # preview production build
 npm run build-widget # build and copy into docs/widget
 ```
 
+Before committing changes to the repository, run `npm run build-widget`
+to refresh the files inside `docs/widget`. This keeps the deployed
+decision tree up‑to‑date.
+
 ## Repository layout
 
 ```

--- a/decision-tree-app/build-widget.sh
+++ b/decision-tree-app/build-widget.sh
@@ -1,31 +1,14 @@
 #!/bin/bash
 
 # Build the decision-tree-app and copy the output to docs/widget
-# Uses npmjs.org registry, falling back to npmmirror.com if needed.
-
 set -e
 
-npm config set registry https://registry.npmjs.org/
-npm ci --legacy-peer-deps || npm install --legacy-peer-deps
-if [ $? -ne 0 ]; then
-  npm config set registry https://registry.npmmirror.com/
-  npm ci --legacy-peer-deps || npm install --legacy-peer-deps
-fi
-
-if [ $? -ne 0 ]; then
-  echo "❌ وابستگی‌ها نصب نشدند (حتی با legacy-peer-deps). راه‌حل: نسخه vite یا پلاگین را اصلاح کن."
-  exit 1
-fi
-
+npm ci --legacy-peer-deps
 npm run build
-# Copy widget build to docs/widget and also place assets under docs/assets
 
-# Copy the entire dist folder to docs/widget so that index.html and
-# its hashed assets live together under docs/widget/assets
+# Replace docs/widget contents with the new build
+rm -rf ../docs/widget/*
 mkdir -p ../docs/widget
 cp -r dist/* ../docs/widget/
 
-# Update index.html asset paths to use the local assets folder
-sed -i 's|/parsanaenergy/assets/|assets/|g' ../docs/widget/index.html
-
-echo "✅ نصب و build با موفقیت انجام شد، فایل‌ها به docs/widget منتقل شدند."
+echo "✅ build completed and files copied to docs/widget"

--- a/decision-tree-app/vite.config.js
+++ b/decision-tree-app/vite.config.js
@@ -4,7 +4,7 @@ import markdown from 'vite-plugin-md';
 
 export default defineConfig({
   plugins: [react(), markdown()],
-  base: '/parsanaenergy/',
+  base: './',
   server: {
     fs: {
       allow: ['..'],

--- a/docs/widget/index.html
+++ b/docs/widget/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Decision Tree App</title>
-    <script type="module" crossorigin src="assets/index-DL91WKal.js"></script>
-    <link rel="stylesheet" crossorigin href="assets/index-B-e6zC8L.css">
+    <script type="module" crossorigin src="./assets/index-DL91WKal.js"></script>
+    <link rel="stylesheet" crossorigin href="./assets/index-B-e6zC8L.css">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- use relative base path in decision-tree widget
- simplify build-widget.sh and clear old files
- run widget build in deploy workflow
- document building widget before commits

## Testing
- `npm run lint` in `decision-tree-app`
- `npm run build` in `decision-tree-app`
- `npm run build` in `docs`


------
https://chatgpt.com/codex/tasks/task_e_68844e7b80508328a1f832f58dbb037e