### PR TITLE
Fix Node.js caching by specifying lockfile path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           node-version: 18
           cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
 
       - name: Build decision tree widget
         working-directory: decision-tree-app


### PR DESCRIPTION
## Summary
- configure `setup-node` to find lock files in subprojects

## Testing
- `npm ci --legacy-peer-deps` in `decision-tree-app`
- `npm run build` in `decision-tree-app`
- `npm ci` in `docs`
- `npm run build` in `docs`


------
https://chatgpt.com/codex/tasks/task_e_688466fe23b48328b7835fbf1825d459