### PR TITLE
Add security headers to docs

### DIFF
--- a/docs/_headers
+++ b/docs/_headers
@@ -1,0 +1,6 @@
+/*
+  Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+  Content-Security-Policy: default-src 'self'; img-src 'self'; script-src 'self'; style-src 'self'; frame-src 'self'
+  X-Frame-Options: SAMEORIGIN
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin


### PR DESCRIPTION
## Summary
- add `_headers` file to configure important security headers for the static site

## Testing
- `npx playwright test` *(fails: page.goto: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68870d6d645083289bb7a377bf68f843