### PR TITLE
Fix iframe path for widget

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -90,7 +90,7 @@
   <section id="decision-tree" class="my-16">
     <h2>درخت تصمیم‌گیری</h2>
     <iframe
-      src="/widget/index.html"
+      src="widget/index.html"
       id="decision-tree-widget"
       style="width:100%;min-height:600px;border:none;"
       loading="lazy"


### PR DESCRIPTION
## Summary
- fix the iframe src path in `docs/index.html`

## Testing
- `curl -I http://127.0.0.1:8080/widget/index.html`

------
https://chatgpt.com/codex/tasks/task_e_68870dbad3ec8328a0f423b278a61ebe