### PR TITLE
Add lazy loading to project thumbnails

### DIFF
--- a/docs/articles/monthly-generator-pm-checklist.html
+++ b/docs/articles/monthly-generator-pm-checklist.html
@@ -70,7 +70,7 @@
 
       <section class="suggested-articles-grid">
         <div class="suggest-card">
-          <img src="../images/generator.png" alt="راهنمای انتخاب ژنراتور">
+          <img src="../images/generator.png" alt="راهنمای انتخاب ژنراتور" loading="lazy">
           <div class="suggest-card-content">
             <h4>راهنمای انتخاب ژنراتور</h4>
             <p>نکات مهم هنگام خرید ژنراتور مناسب پروژه.</p>
@@ -78,7 +78,7 @@
           </div>
         </div>
         <div class="suggest-card">
-          <img src="../images/solar.png" alt="مزایای برق خورشیدی">
+          <img src="../images/solar.png" alt="مزایای برق خورشیدی" loading="lazy">
           <div class="suggest-card-content">
             <h4>مزایای برق خورشیدی</h4>
             <p>چگونه با نیروگاه خورشیدی هزینه برق را کاهش دهیم.</p>
@@ -86,7 +86,7 @@
           </div>
         </div>
         <div class="suggest-card">
-          <img src="../images/ups.png" alt="اهمیت UPS">
+          <img src="../images/ups.png" alt="اهمیت UPS" loading="lazy">
           <div class="suggest-card-content">
             <h4>اهمیت UPS در صنایع</h4>
             <p>نقش UPS در حفظ تجهیزات حساس.</p>
@@ -98,22 +98,22 @@
 
     <aside class="sidebar">
       <div class="author-card">
-        <img src="../images/logo.png" alt="پارسانا انرژی">
+        <img src="../images/logo.png" alt="پارسانا انرژی" loading="lazy">
         <p><strong>پارسانا انرژی</strong></p>
         <p>تامین کننده راهکارهای برق پایدار</p>
       </div>
       <div class="related-articles">
         <h3>مطالب مرتبط</h3>
         <div class="related-mini-card">
-          <img src="../images/generator.png" alt="تعمیرات دوره‌ای">
+          <img src="../images/generator.png" alt="تعمیرات دوره‌ای" loading="lazy">
           <a href="#">تعمیرات دوره‌ای دیزل ژنراتور</a>
         </div>
         <div class="related-mini-card">
-          <img src="../images/ups.png" alt="ظرفیت UPS">
+          <img src="../images/ups.png" alt="ظرفیت UPS" loading="lazy">
           <a href="#">انتخاب ظرفیت UPS مناسب</a>
         </div>
         <div class="related-mini-card">
-          <img src="../images/solar.png" alt="پنل خورشیدی">
+          <img src="../images/solar.png" alt="پنل خورشیدی" loading="lazy">
           <a href="#">آشنایی با پنل‌های خورشیدی</a>
         </div>
       </div>

--- a/docs/catalog/catalog.html
+++ b/docs/catalog/catalog.html
@@ -55,12 +55,12 @@
     });
   </script>
   <noscript>
-    <img class="catalog-img" src="catalog_pages-to-jpg-0001.jpg" alt="صفحه 1" />
-    <img class="catalog-img" src="catalog_pages-to-jpg-0002.jpg" alt="صفحه 2" />
-    <img class="catalog-img" src="catalog_pages-to-jpg-0003.jpg" alt="صفحه 3" />
-    <img class="catalog-img" src="catalog_pages-to-jpg-0004.jpg" alt="صفحه 4" />
-    <img class="catalog-img" src="catalog_pages-to-jpg-0005.jpg" alt="صفحه 5" />
-    <img class="catalog-img" src="catalog_pages-to-jpg-0006.jpg" alt="صفحه 6" />
+    <img class="catalog-img" src="catalog_pages-to-jpg-0001.jpg" alt="صفحه 1" loading="lazy" />
+    <img class="catalog-img" src="catalog_pages-to-jpg-0002.jpg" alt="صفحه 2" loading="lazy" />
+    <img class="catalog-img" src="catalog_pages-to-jpg-0003.jpg" alt="صفحه 3" loading="lazy" />
+    <img class="catalog-img" src="catalog_pages-to-jpg-0004.jpg" alt="صفحه 4" loading="lazy" />
+    <img class="catalog-img" src="catalog_pages-to-jpg-0005.jpg" alt="صفحه 5" loading="lazy" />
+    <img class="catalog-img" src="catalog_pages-to-jpg-0006.jpg" alt="صفحه 6" loading="lazy" />
   </noscript>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -115,19 +115,19 @@
     <h2>محصولات</h2>
     <div class="products-grid">
       <div class="product-card">
-        <img src="images/generator.png" alt="ژنراتور">
+        <img src="images/generator.png" alt="ژنراتور" loading="lazy">
         <h3>ژنراتور دیزلی</h3>
         <p>راهکاری مطمئن برای تامین برق در شرایط اضطراری.</p>
         <a href="#" class="btn-primary">جزئیات بیشتر</a>
       </div>
       <div class="product-card">
-        <img src="images/battery.png" alt="باتری">
+        <img src="images/battery.png" alt="باتری" loading="lazy">
         <h3>باتری صنعتی</h3>
         <p>ذخیره انرژی با طول عمر بالا و نگهداری آسان.</p>
         <a href="#" class="btn-primary">جزئیات بیشتر</a>
       </div>
       <div class="product-card">
-        <img src="images/solar.png" alt="پنل خورشیدی">
+        <img src="images/solar.png" alt="پنل خورشیدی" loading="lazy">
         <h3>پنل خورشیدی</h3>
         <p>تولید برق پاک برای مصارف خانگی و تجاری.</p>
         <a href="#" class="btn-primary">جزئیات بیشتر</a>
@@ -140,13 +140,13 @@
     <h2>پروژه‌های ما</h2>
     <div class="projects-grid">
       <div class="project-item" data-title="پروژه 1" data-description="توضیح کوتاه درباره پروژه 1">
-        <img src="images/generator.png" alt="پروژه 1">
+        <img src="images/generator.png" alt="پروژه 1" loading="lazy">
       </div>
       <div class="project-item" data-title="پروژه 2" data-description="توضیح کوتاه درباره پروژه 2">
-        <img src="images/battery.png" alt="پروژه 2">
+        <img src="images/battery.png" alt="پروژه 2" loading="lazy">
       </div>
       <div class="project-item" data-title="پروژه 3" data-description="توضیح کوتاه درباره پروژه 3">
-        <img src="images/solar.png" alt="پروژه 3">
+        <img src="images/solar.png" alt="پروژه 3" loading="lazy">
       </div>
     </div>
   </section>
@@ -154,7 +154,7 @@
   <div id="project-modal" class="hidden" aria-hidden="true">
     <div class="modal-content">
       <span class="close-modal" aria-label="Close">&times;</span>
-      <img src="" alt="تصویر پروژه نمونه">
+      <img src="" alt="تصویر پروژه نمونه" loading="lazy">
       <h3></h3>
       <p></p>
     </div>

--- a/docs/services/index.html
+++ b/docs/services/index.html
@@ -19,40 +19,40 @@
     </section>
     <section class="categories-list">
       <div class="category-card" data-category="maint">
-        <img src="../images/generator.png" alt="سرویس ژنراتور" />
+        <img src="../images/generator.png" alt="سرویس ژنراتور" loading="lazy" />
         <span>سرویس ژنراتور</span>
       </div>
       <div class="category-card" data-category="solar">
-        <img src="../images/solar.png" alt="نیروگاه خورشیدی" />
+        <img src="../images/solar.png" alt="نیروگاه خورشیدی" loading="lazy" />
         <span>نیروگاه خورشیدی</span>
       </div>
       <div class="category-card" data-category="battery">
-        <img src="../images/battery.png" alt="باتری" />
+        <img src="../images/battery.png" alt="باتری" loading="lazy" />
         <span>باتری صنعتی</span>
       </div>
     </section>
     <section class="services-list hidden">
       <button class="back-btn">بازگشت</button>
       <div class="service-card" data-category="maint">
-        <img src="../images/generator-maintenance-check.png" alt="تعویض فیلتر" />
+        <img src="../images/generator-maintenance-check.png" alt="تعویض فیلتر" loading="lazy" />
         <h2>تعویض فیلتر ژنراتور</h2>
         <p>تعویض دوره‌ای انواع فیلتر جهت عملکرد بهینه.</p>
         <button class="contact-btn">درخواست مشاوره</button>
       </div>
       <div class="service-card" data-category="maint">
-        <img src="../images/oil-analysis-generator.png" alt="آنالیز روغن" />
+        <img src="../images/oil-analysis-generator.png" alt="آنالیز روغن" loading="lazy" />
         <h2>آنالیز روغن ژنراتور</h2>
         <p>بررسی کیفیت روغن و ارائه گزارش تخصصی.</p>
         <button class="contact-btn">درخواست مشاوره</button>
       </div>
       <div class="service-card" data-category="solar">
-        <img src="../images/solar.png" alt="طراحی نیروگاه" />
+        <img src="../images/solar.png" alt="طراحی نیروگاه" loading="lazy" />
         <h2>طراحی نیروگاه خورشیدی</h2>
         <p>محاسبه و طراحی سیستم خورشیدی متناسب با نیاز شما.</p>
         <button class="contact-btn">درخواست مشاوره</button>
       </div>
       <div class="service-card" data-category="battery">
-        <img src="../images/battery.png" alt="نصب باتری" />
+        <img src="../images/battery.png" alt="نصب باتری" loading="lazy" />
         <h2>نصب و تست باتری</h2>
         <p>راه‌اندازی و سرویس کامل انواع باتری صنعتی.</p>
         <button class="contact-btn">درخواست مشاوره</button>


### PR DESCRIPTION
## Summary
- improve homepage project thumbnails and product cards with `loading="lazy"`
- lazily load service images, catalog pages, and related article images

## Testing
- `npx playwright test` *(fails: page.goto net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6887107cf4e88328a0169e19243751d8