### PR TITLE
Bundle CSS with Vite

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,9 +6,8 @@
   <title>Parsana Energy</title>
   <link rel="icon" href="/parsanaenergy/images/favicon.ico" />
   <!-- استایل اصلی سفارشی سایت -->
-  <link rel="stylesheet" href="css/style.css" />
   <!-- Bundle CSS خروجی Vite (hashed) -->
-  <link rel="stylesheet" href="./assets/index-E4_dY-yQ.css" />
+  <link rel="preload" href="./assets/index-E4_dY-yQ.css" as="style" />
   <!-- استایل ویجت (اگر لازمه) -->
   <link rel="stylesheet" href="assets/widget-style.css" />
   <!-- Bundle JS خروجی Vite (hashed) -->

--- a/docs/src/main.jsx
+++ b/docs/src/main.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.jsx';
+import '../css/style.css';
 
 const container = document.getElementById('root') || document.getElementById('widget-root');
 if (container && !container._reactRootContainer) {


### PR DESCRIPTION
## Summary
- inline global styles via Vite in `main.jsx`
- drop direct stylesheet link and preload the Vite bundle

Measured LCP using Playwright after build: ~436 ms.

## Testing
- `npm run build:site`
- `node measure-lcp.cjs` *(reported LCP 436 ms)*

------
https://chatgpt.com/codex/tasks/task_e_68870fe679c48328a0b3890035256d5a