### PR TITLE
Add Envoy security headers and meta tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,15 @@ separately with unique hashes to avoid conflicts.
     ├── src
     └── vite.config.js
 ```
+
+## Envoy configuration
+
+The `envoy/envoy.yaml` file configures Envoy to inject common security headers into every response. Start your static site on port `8000` (e.g. `npm run preview` in `docs`) and launch Envoy:
+
+```bash
+docker run --rm -p 8080:8080 \
+  -v $(pwd)/envoy/envoy.yaml:/etc/envoy/envoy.yaml \
+  envoyproxy/envoy:v1.29-latest
+```
+
+Then open `http://localhost:8080`.

--- a/decision-tree-app/index.html
+++ b/decision-tree-app/index.html
@@ -4,6 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Decision Tree App</title>
+<meta http-equiv="Strict-Transport-Security" content="max-age=63072000; includeSubDomains; preload" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'" />
+<meta http-equiv="X-Frame-Options" content="DENY" />
+<meta http-equiv="X-Content-Type-Options" content="nosniff" />
+<meta http-equiv="Referrer-Policy" content="same-origin" />
   </head>
   <body>
     <div id="widget-root"></div>

--- a/docs/404.html
+++ b/docs/404.html
@@ -4,6 +4,11 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>صفحه مورد نظر یافت نشد</title>
+<meta http-equiv="Strict-Transport-Security" content="max-age=63072000; includeSubDomains; preload" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'" />
+<meta http-equiv="X-Frame-Options" content="DENY" />
+<meta http-equiv="X-Content-Type-Options" content="nosniff" />
+<meta http-equiv="Referrer-Policy" content="same-origin" />
   <link rel="stylesheet" href="css/style.min.css" />
 </head>
 <body>

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -4,6 +4,11 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>وبلاگ پارسانا انرژی</title>
+<meta http-equiv="Strict-Transport-Security" content="max-age=63072000; includeSubDomains; preload" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'" />
+<meta http-equiv="X-Frame-Options" content="DENY" />
+<meta http-equiv="X-Content-Type-Options" content="nosniff" />
+<meta http-equiv="Referrer-Policy" content="same-origin" />
   <meta name="description" content="مشاوره، فروش و اجاره تجهیزات برق اضطراری و انرژی خورشیدی" />
   <link rel="canonical" href="https://parsanaenergy.ir/articles/" />
   <meta property="og:title" content="وبلاگ پارسانا انرژی" />

--- a/docs/articles/monthly-generator-pm-checklist.html
+++ b/docs/articles/monthly-generator-pm-checklist.html
@@ -4,6 +4,11 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>چک لیست سرویس ماهانه ژنراتور</title>
+<meta http-equiv="Strict-Transport-Security" content="max-age=63072000; includeSubDomains; preload" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'" />
+<meta http-equiv="X-Frame-Options" content="DENY" />
+<meta http-equiv="X-Content-Type-Options" content="nosniff" />
+<meta http-equiv="Referrer-Policy" content="same-origin" />
   <meta name="description" content="مشاوره، فروش و اجاره تجهیزات برق اضطراری و انرژی خورشیدی" />
   <link rel="canonical" href="https://parsanaenergy.ir/articles/monthly-generator-pm-checklist.html" />
   <meta property="og:title" content="چک لیست سرویس ماهانه ژنراتور" />

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -3,6 +3,11 @@
   <head>
     <meta charset="utf-8" />
     <script>
+<meta http-equiv="Strict-Transport-Security" content="max-age=63072000; includeSubDomains; preload" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'" />
+<meta http-equiv="X-Frame-Options" content="DENY" />
+<meta http-equiv="X-Content-Type-Options" content="nosniff" />
+<meta http-equiv="Referrer-Policy" content="same-origin" />
       window.location.href = "/parsanaenergy/docs/articles/";
     </script>
     <title>Redirecting...</title>

--- a/docs/catalog/catalog.html
+++ b/docs/catalog/catalog.html
@@ -4,6 +4,11 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>کاتالوگ پارسانا انرژی</title>
+<meta http-equiv="Strict-Transport-Security" content="max-age=63072000; includeSubDomains; preload" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'" />
+<meta http-equiv="X-Frame-Options" content="DENY" />
+<meta http-equiv="X-Content-Type-Options" content="nosniff" />
+<meta http-equiv="Referrer-Policy" content="same-origin" />
   <link rel="stylesheet" href="../css/style.min.css" />
   <link rel="stylesheet" href="../assets/services-style.css" />
   <style>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,11 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Parsana Energy</title>
+<meta http-equiv="Strict-Transport-Security" content="max-age=63072000; includeSubDomains; preload" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'" />
+<meta http-equiv="X-Frame-Options" content="DENY" />
+<meta http-equiv="X-Content-Type-Options" content="nosniff" />
+<meta http-equiv="Referrer-Policy" content="same-origin" />
   <meta name="description" content="مشاوره، فروش و اجاره تجهیزات برق اضطراری و انرژی خورشیدی" />
   <link rel="canonical" href="https://parsanaenergy.ir/" />
   <meta property="og:title" content="Parsana Energy" />

--- a/docs/services/index.html
+++ b/docs/services/index.html
@@ -4,6 +4,11 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>کاتالوگ خدمات - پارسانا انرژی</title>
+<meta http-equiv="Strict-Transport-Security" content="max-age=63072000; includeSubDomains; preload" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'" />
+<meta http-equiv="X-Frame-Options" content="DENY" />
+<meta http-equiv="X-Content-Type-Options" content="nosniff" />
+<meta http-equiv="Referrer-Policy" content="same-origin" />
   <link rel="stylesheet" href="../css/style.min.css" />
   <link rel="stylesheet" href="../assets/services-style.css" />
 </head>

--- a/docs/widget/index.html
+++ b/docs/widget/index.html
@@ -4,6 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Decision Tree App</title>
+<meta http-equiv="Strict-Transport-Security" content="max-age=63072000; includeSubDomains; preload" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'" />
+<meta http-equiv="X-Frame-Options" content="DENY" />
+<meta http-equiv="X-Content-Type-Options" content="nosniff" />
+<meta http-equiv="Referrer-Policy" content="same-origin" />
     <script type="module" crossorigin src="./assets/index-CLocwXec.js"></script>
     <link rel="stylesheet" crossorigin href="./assets/index-B-e6zC8L.css">
   </head>

--- a/envoy/envoy.yaml
+++ b/envoy/envoy.yaml
@@ -1,0 +1,64 @@
+static_resources:
+  listeners:
+  - name: listener_http
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 8080
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: site
+              domains: ["*"]
+              routes:
+              - match: { prefix: "/" }
+                route: { cluster: site_backend }
+          http_filters:
+          - name: envoy.filters.http.header_mutation
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
+              mutations:
+                response_mutations:
+                - append:
+                    header:
+                      key: Strict-Transport-Security
+                      value: "max-age=63072000; includeSubDomains; preload"
+                - append:
+                    header:
+                      key: Content-Security-Policy
+                      value: "default-src 'self'"
+                - append:
+                    header:
+                      key: X-Frame-Options
+                      value: "DENY"
+                - append:
+                    header:
+                      key: X-Content-Type-Options
+                      value: "nosniff"
+                - append:
+                    header:
+                      key: Referrer-Policy
+                      value: "same-origin"
+          - name: envoy.filters.http.router
+            typed_config: {}
+  clusters:
+  - name: site_backend
+    connect_timeout: 0.25s
+    type: logical_dns
+    lb_policy: round_robin
+    dns_lookup_family: V4_ONLY
+    load_assignment:
+      cluster_name: site_backend
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 8000


### PR DESCRIPTION
## Summary
- add Envoy config injecting security headers
- inject matching meta http-equiv tags into all HTML files
- document running Envoy in README

## Testing
- `npm test` *(fails: page.goto net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68872750d2808328b112a4a2c52eb9bf