### PR TITLE
Add deploy script for hashed docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "playwright install --with-deps && playwright test"
+    "test": "playwright install --with-deps && playwright test",
+    "build:widget": "cd decision-tree-app && npm i --legacy-peer-deps && npm run build-widget",
+    "build:site": "cd docs && npm i && npm run build",
+    "deploy": "npm run build:widget && npm run build:site && rsync -a --delete docs/dist/ docs/ && rm -rf docs/dist"
   },
   "devDependencies": {
     "@playwright/test": "^1.44.0"


### PR DESCRIPTION
## Summary
- add scripts to root package.json for building widget and docs
- add unified deploy command cleaning old hash files

## Testing
- `npm test` *(fails: net::ERR_CONNECTION_REFUSED at http://localhost:4173/parsanaenergy/)*

------
https://chatgpt.com/codex/tasks/task_e_68873ef0e0ec8328b4bd9d9659696094