### PR TITLE
Ensure hashed assets and update HTML references

### DIFF
--- a/decision-tree-app/build-widget.sh
+++ b/decision-tree-app/build-widget.sh
@@ -12,4 +12,7 @@ rm -f ../docs/widget/assets/*
 cp dist/assets/* ../docs/widget/assets/
 cp dist/index.html ../docs/widget/index.html
 
+# Update HTML references with new hashed filenames
+node ../scripts/update-html-hashes.js dist ../docs/widget/index.html
+
 echo "✅ build completed and files copied to docs/widget"

--- a/decision-tree-app/package.json
+++ b/decision-tree-app/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://sajjadzea.github.io/parsanaenergy/",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && node ../scripts/update-html-hashes.js dist dist",
     "build-widget": "bash build-widget.sh",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/decision-tree-app/vite.config.js
+++ b/decision-tree-app/vite.config.js
@@ -8,6 +8,8 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     emptyOutDir: true,
+    assetsInlineLimit: 0,
+    manifest: true,
   },
   server: {
     fs: {

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build && npm run minify",
+    "build": "vite build && npm run minify && node ../scripts/update-html-hashes.js dist dist",
     "minify": "cssnano css/style.css css/style.min.css && terser js/articles.js -c -m -o js/articles.min.js && terser js/main.js -c -m -o js/main.min.js && terser js/services.js -c -m -o js/services.min.js",
     "preview": "vite preview",
     "predeploy": "npm run build",

--- a/docs/vite.config.js
+++ b/docs/vite.config.js
@@ -7,5 +7,7 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     emptyOutDir: true,
+    assetsInlineLimit: 0,
+    manifest: true,
   },
 });

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "playwright install --with-deps && playwright test",
     "build:widget": "cd decision-tree-app && npm i --legacy-peer-deps && npm run build-widget",
     "build:site": "cd docs && npm i && npm run build",
-    "deploy": "npm run build:widget && npm run build:site && rsync -a --delete docs/dist/ docs/ && rm -rf docs/dist"
+    "deploy": "npm run build:widget && npm run build:site && rsync -a --delete docs/dist/ docs/ && node scripts/update-html-hashes.js docs/dist docs docs/articles docs/blog docs/catalog docs/services docs/widget && rm -rf docs/dist"
   },
   "devDependencies": {
     "@playwright/test": "^1.44.0"

--- a/scripts/update-html-hashes.js
+++ b/scripts/update-html-hashes.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+function collectHtmlFiles(targets) {
+  const htmlFiles = [];
+  for (const p of targets) {
+    const stat = fs.statSync(p);
+    if (stat.isDirectory()) {
+      for (const f of fs.readdirSync(p)) {
+        if (f.endsWith('.html')) htmlFiles.push(path.join(p, f));
+      }
+    } else if (p.endsWith('.html')) {
+      htmlFiles.push(p);
+    }
+  }
+  return htmlFiles;
+}
+
+function updateHtml(distDir, htmlTargets) {
+  const assetsDir = path.join(distDir, 'assets');
+  if (!fs.existsSync(assetsDir)) return;
+  const files = fs.readdirSync(assetsDir);
+  const replacements = {};
+  for (const file of files) {
+    if (!file.endsWith('.js') && !file.endsWith('.css')) continue;
+    const ext = path.extname(file);
+    const prefix = file.split('-')[0];
+    replacements[prefix + ext] = file;
+  }
+
+  const htmlFiles = collectHtmlFiles(htmlTargets);
+  for (const htmlFile of htmlFiles) {
+    let content = fs.readFileSync(htmlFile, 'utf8');
+    for (const [key, hashed] of Object.entries(replacements)) {
+      const ext = path.extname(key);
+      const prefix = key.replace(ext, '');
+      const regex = new RegExp(prefix + '-[A-Za-z0-9]+\\' + ext, 'g');
+      content = content.replace(regex, hashed);
+    }
+    fs.writeFileSync(htmlFile, content);
+  }
+}
+
+const [,, distDir, ...htmlFiles] = process.argv;
+if (!distDir || htmlFiles.length === 0) {
+  console.error('Usage: update-html-hashes <distDir> <htmlFileOrDir...>');
+  process.exit(1);
+}
+updateHtml(distDir, htmlFiles);


### PR DESCRIPTION
## Summary
- enforce `assetsInlineLimit: 0` in Vite configs
- add script to replace old hashed filenames in HTML files
- update build and deploy scripts to run the replacement step

## Testing
- `npm test` *(fails: page.goto ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68878e5a77b483288ac701d048285826