### PR TITLE
Fix stale asset references after build

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build && npm run minify",
+    "build": "vite build && npm run minify && node ../update-hashed-assets.js",
     "minify": "cssnano css/style.css css/style.min.css && terser js/articles.js -c -m -o js/articles.min.js && terser js/main.js -c -m -o js/main.min.js && terser js/services.js -c -m -o js/services.min.js",
     "preview": "vite preview",
     "predeploy": "npm run build",

--- a/update-hashed-assets.js
+++ b/update-hashed-assets.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const docsDir = new URL('./docs/', import.meta.url);
+
+const assets = [];
+
+async function collectAssets(rel = '.') {
+  const dir = path.join(docsDir.pathname, rel);
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const entryRel = path.posix.join(rel, entry.name);
+    if (entry.isDirectory()) {
+      await collectAssets(entryRel);
+    } else {
+      const m = entry.name.match(/^(.+)-[A-Za-z0-9_-]+\.(css|js)$/);
+      if (m) {
+        assets.push({
+          dir: rel === '.' ? '' : rel,
+          base: m[1],
+          ext: m[2],
+          file: entry.name,
+        });
+      }
+    }
+  }
+}
+
+const htmlFiles = [];
+
+async function collectHtml(rel = '.') {
+  const dir = path.join(docsDir.pathname, rel);
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const entryRel = path.posix.join(rel, entry.name);
+    if (entry.isDirectory()) {
+      await collectHtml(entryRel);
+    } else if (entry.name.endsWith('.html')) {
+      htmlFiles.push(entryRel);
+    }
+  }
+}
+
+function escape(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function replacePaths(content, dir, base, ext, file) {
+  const hashedPart = file.slice(base.length + 1); // portion after base-
+  const lookbehind = dir === 'assets' ? '(?<!widget\\/)' : '';
+  const dirRegex = dir ? `${lookbehind}${escape(dir)}` : lookbehind;
+  const pattern = `(["'])([^"']*${dirRegex ? dirRegex + '/' : ''}${base})-[A-Za-z0-9_-]+\\.${ext}(["'])`;
+  const regex = new RegExp(pattern, 'g');
+  return content.replace(regex, `$1$2-${hashedPart}$3`);
+}
+
+async function processHtml(rel) {
+  const filePath = path.join(docsDir.pathname, rel);
+  let content = await fs.readFile(filePath, 'utf8');
+  let updated = content;
+  // sort assets by dir length descending to handle nested dirs first
+  const sorted = assets.slice().sort((a,b) => b.dir.length - a.dir.length);
+  for (const a of sorted) {
+    updated = replacePaths(updated, a.dir, a.base, a.ext, a.file);
+  }
+  if (updated !== content) {
+    await fs.writeFile(filePath, updated);
+    console.log(`Updated ${rel}`);
+  }
+}
+
+async function main() {
+  await collectAssets('.');
+  await collectHtml('.');
+  for (const file of htmlFiles) {
+    await processHtml(file);
+  }
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a script to update hashed asset links in `docs` html files
- run this updater after the docs build step

## Testing
- `npm test` *(fails: page.goto net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_688792f67bf4832890d18f891437d12c