### PR TITLE
Enable automatic GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,50 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'decision-tree-app/**'
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: |
+            docs/package-lock.json
+            decision-tree-app/package-lock.json
+
+      - name: Build decision tree widget
+        working-directory: decision-tree-app
+        run: |
+          npm ci
+          npm run build-widget
+
+      - name: Build docs site
+        working-directory: docs
+        run: |
+          npm ci
+          npm run build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/dist
+          publish_branch: gh-pages
+          cname: parsanaenergy.ir
+          enable_jekyll: false
+


### PR DESCRIPTION
## Summary
- build widget and docs on pushes to `main`
- deploy the built site to `gh-pages` with the custom domain

## Testing
- `npm test` *(fails: page.goto net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68879c4c42708328ae1c870bd8827463