### PR TITLE
Hot-fix: unblock landing page while widget is under repair (#73)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,7 +24,8 @@ jobs:
         with:
           node-version: 18
           cache: 'npm'
-      - name: Build widget
+      - name: Build decision-tree widget
+        continue-on-error: true
         working-directory: decision-tree-app
         run: |
           npm ci --legacy-peer-deps
@@ -39,6 +40,7 @@ jobs:
         with:
           path: docs/dist
   deploy:
+    if: ${{ always() }}
     needs: build
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
## Summary
- allow the decision-tree widget step to fail without stopping the workflow
- ensure the deploy job runs even when the build job is marked as failed

## Why
- until the widget is fixed, the landing page should still build and deploy
- we'll revert `continue-on-error` once the widget bug is resolved


------
https://chatgpt.com/codex/tasks/task_e_6887b47ce6388328805026b2b1989500