### PR TITLE
Remove leftover rsync that caused exit 24 (#81)

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -6,8 +6,6 @@
   "scripts": {
     "dev": "vite",
     "minify": "cssnano css/style.css css/style.min.css && terser js/articles.js -c -m -o js/articles.min.js && terser js/main.js -c -m -o js/main.min.js && terser js/services.js -c -m -o js/services.min.js",
-    "prebuild": "rimraf dist",
-    "clean": "rimraf dist",
     "build": "vite build",
     "preview": "vite preview",
     "predeploy": "npm run build",


### PR DESCRIPTION
## Summary
- remove `prebuild` and `clean` scripts from `docs/package.json`
- keep the docs build step as just `vite build`

## Testing
- `npm run build:site`
- `npm test` *(fails: locator not found)*

------
https://chatgpt.com/codex/tasks/task_e_68883dc3ae4c8328b9bf8ec5953cda49