### PR TITLE
Serve built Vite dist instead of dev source (#83)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,7 +33,8 @@ jobs:
       - name: Build landing
         working-directory: docs
         run: |
-          npm ci --legacy-peer-deps
+          rm -f ../docs/index.html  # remove dev entrypoint
+          npm ci --ignore-engines
           npm run build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- tweak GitHub Pages workflow to only upload built files
- clean dev `index.html` before building

## Testing
- `npm test` *(fails: page.goto net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68884e5df0c48328b84a117fc2c0f1e6