### PR TITLE
fix: resolve Vite build failure by ensuring index.html and correct build path

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -43,10 +43,9 @@ jobs:
         run: |
           npm ci --legacy-peer-deps
           npm run build-widget
-      - name: Build landing
-        working-directory: docs
+      - name: Build site
         run: |
-          rm -f ../docs/index.html  # remove dev entrypoint
+          cd docs
           npm ci --ignore-engines
           npm run build
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- ensure `pages.yml` builds from the `docs` directory without deleting `index.html`

## Testing
- `npm run build:site`
- `npm test` *(fails: Decision-Tree widget loads)*

------
https://chatgpt.com/codex/tasks/task_e_6889b2a956d48328b46acfe4df57bb99