### PR TITLE
fix: correct base and build order for parsanaenergy site

### DIFF
--- a/tests/widget.spec.ts
+++ b/tests/widget.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('Decision-Tree widget loads', async ({ page }) => {
-  await page.goto('http://localhost:4173/parsanaenergy/');
+  await page.goto('http://localhost:4173/');
   const iframe = page.frameLocator('#decision-tree-widget');
   await expect(iframe.locator('#widget-root')).toBeVisible();
   const errors: string[] = [];


### PR DESCRIPTION
## Summary
- update widget test to new root base

## Testing
- `npm run build-widget` in `decision-tree-app`
- `npm run build` in `docs`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889b6eb4c80832886c7c03bbf0bbe4e