### PR TITLE
fix: optimize and fix CI/CD workflows for multi-project Vite site

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 20.19.x
+          node-version: 20
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
 
@@ -39,13 +39,15 @@ jobs:
         working-directory: decision-tree-app
         run: |
           npm run build
-          rm -rf ../docs/widget/*
-          mkdir -p ../docs/widget
-          cp -r dist/* ../docs/widget/
 
       - name: Build docs site
         working-directory: docs
         run: npm run build
+
+      - name: Copy widget to dist
+        run: |
+          mkdir -p docs/dist/widget
+          cp -r decision-tree-app/dist/* docs/dist/widget/
 
 
       - name: Run tests
@@ -61,8 +63,8 @@ jobs:
         if: github.event_name == 'push'
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.AGENTTEST }}
-          publish_dir: ./docs
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/dist
           enable_jekyll: false
           user_name: github-actions[bot]
           user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -38,17 +38,21 @@ jobs:
           node-version: 20
           cache: 'npm'
       - name: Build decision-tree widget
-        continue-on-error: true
         working-directory: decision-tree-app
         run: |
           npm ci --legacy-peer-deps
-          npm run build-widget
+          npm run build
       - name: Build site
         working-directory: docs
         run: |
           npm ci --ignore-engines
           npm run build
+      - name: Copy widget to dist
+        run: |
+          mkdir -p docs/dist/widget
+          cp -r decision-tree-app/dist/* docs/dist/widget/
       - name: Copy CNAME
+        if: ${{ hashFiles('docs/CNAME') != '' }}
         run: cp docs/CNAME docs/dist/CNAME
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
@@ -56,7 +60,6 @@ jobs:
           path: docs/dist
           name: github-pages
   deploy:
-    if: ${{ always() }}
     needs: build_site
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
## Summary
- update GitHub Actions to checkout/setup node with latest versions
- ensure widget build output copies to `docs/dist` and deploy from that folder
- use `GITHUB_TOKEN` for deploying
- only deploy pages after successful build and copy CNAME conditionally

## Testing
- `npm ci`
- `npx playwright install --with-deps`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889b90f1210832881d6a17bb90b4e28