### PR TITLE
fix(ci): resolve action version and unblock Pages deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -56,7 +56,7 @@ jobs:
           touch .nojekyll
           if [ -f ../../docs/CNAME ]; then cp ../../docs/CNAME ./CNAME; fi
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v1
         with:
           path: ./docs/dist
           name: github-pages


### PR DESCRIPTION
## Summary
- update Pages workflow to use upload-pages-artifact@v1

This only adjusts GitHub Actions configuration. No runtime code is affected.

## Testing
- `npm test` *(fails: Decision-Tree widget not visible)*

------
https://chatgpt.com/codex/tasks/task_e_688cc9448ddc8328957a4cf469568bae