### PR TITLE
ci: fix Pages workflow — replace deprecated artifact action versions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -56,7 +56,7 @@ jobs:
           touch .nojekyll
           if [ -f ../../docs/CNAME ]; then cp ../../docs/CNAME ./CNAME; fi
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3 # v3 bundles upload-artifact@v4
         with:
           path: ./docs/dist
           name: github-pages


### PR DESCRIPTION
## Summary
- upgrade `upload-pages-artifact` to v3 in Pages workflow

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ccc84c39c83289915624619b90989