### PR TITLE
Switch repo to pnpm workspaces

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,9 +21,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: 20, cache: npm }
-      - name: Install deps
-        run: npm ci --ignore-engines
+        with: { node-version: 20, cache: 'pnpm' }
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - run: pnpm install --frozen-lockfile
       - name: Run Playwright tests
         run: |
           npx playwright install --with-deps
@@ -35,17 +37,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'npm'
-      - name: Build decision-tree widget
-        working-directory: decision-tree-app
-        run: |
-          npm ci --legacy-peer-deps
-          npm run build
-      - name: Build site
-        working-directory: docs
-        run: |
-          npm ci --ignore-engines
-          npm run build
+          cache: 'pnpm'
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
       - name: Copy widget to dist
         run: |
           mkdir -p docs/dist/widget

--- a/package.json
+++ b/package.json
@@ -1,8 +1,16 @@
 {
   "name": "parsanaenergy-root",
   "private": true,
+  "packageManager": "pnpm@8.0.0",
+  "workspaces": [
+    "docs",
+    "decision-tree-app"
+  ],
   "type": "module",
   "scripts": {
+    "build": "pnpm -r run build",
+    "dev": "pnpm -r run dev",
+    "lint": "pnpm -r run lint",
     "test": "playwright test || true",
     "build:widget": "cd decision-tree-app && npm i --legacy-peer-deps && npm run build-widget",
     "build:site": "cd docs && npm i && npm run build",


### PR DESCRIPTION
## Summary
- configure `pnpm` workspaces at the repo root
- update GitHub Actions workflow to use pnpm

## Testing
- `pnpm install`
- `pnpm test` *(fails: browser executable missing but exit code was zero)*

------
https://chatgpt.com/codex/tasks/task_e_688cde7cb0208328b33d7a2da3d9b9d5