### PR TITLE
feat(docs): add multi-page build inputs

### DIFF
--- a/docs/vite.config.js
+++ b/docs/vite.config.js
@@ -1,9 +1,22 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const root = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   base: '/',
-  build: { outDir: 'dist', emptyOutDir: true },
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    rollupOptions: {
+      input: {
+        main: resolve(root, 'index.html'),
+        articles: resolve(root, 'articles/index.html'),
+      },
+    },
+  },
   resolve: { alias: { '@widget': '/widget' } },
   plugins: [react()],
 });


### PR DESCRIPTION
## Summary
- support building docs index and articles pages through rollupOptions inputs

## Testing
- `npm test` (fails: net::ERR_CONNECTION_REFUSED at http://localhost:4173/)
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68909ecabb7c83288b182ab4d25ce141