### PR TITLE
feat: verify docs build output

### DIFF
--- a/scripts/verify-docs-build.sh
+++ b/scripts/verify-docs-build.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build docs
+(
+  cd "$(dirname "$0")/../docs"
+  pnpm build
+)
+
+required_files=(
+  "docs/dist/index.html"
+  "docs/dist/articles/index.html"
+  "docs/dist/404.html"
+)
+
+missing=()
+for file in "${required_files[@]}"; do
+  [[ -f "$file" ]] || missing+=("$file")
+fi
+
+if [[ ${#missing[@]} -eq 0 ]]; then
+  echo "✅ All required files exist."
+else
+  echo "❌ Missing files:"
+  for f in "${missing[@]}"; do
+    echo "$f"
+  done
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add script to build docs and ensure key files exist in the dist directory

## Testing
- `./scripts/verify-docs-build.sh` *(fails: rimraf not found)*
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890a22547c083289c2ec1ab4f1b7032