### PR TITLE
Add Playwright test for articles page after deploy

### DIFF
--- a/tests/articles.spec.js
+++ b/tests/articles.spec.js
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test';
+
+test.use({ ignoreHTTPSErrors: true });
+
+test('Articles page is reachable after deploy', async ({ page }) => {
+  const response = await page.goto('https://parsanaenergy.ir/articles/');
+  expect(response?.status(), 'expected HTTP status 200').toBe(200);
+
+  const title = await page.title();
+  expect(title, 'expected title to contain the blog heading').toMatch(/Articles|Blog|مقالات/i);
+});


### PR DESCRIPTION
## Summary
- add Playwright E2E test hitting https://parsanaenergy.ir/articles/ and checking for a valid status and title

## Testing
- `npx playwright test tests/articles.spec.js` *(fails: expected HTTP status 200 but received 404)*
- `npx playwright test` *(fails: articles page returns 404 and widget spec cannot reach localhost:4173)*

------
https://chatgpt.com/codex/tasks/task_e_6890a6c8ad208328ac406e4eb82c0fcc