### PR TITLE
Install pnpm before running pnpm commands

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,9 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with: { node-version: 20, cache: 'pnpm' }
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 8
+      - run: npm install -g pnpm@8
       - run: pnpm install --frozen-lockfile
       - name: Run Playwright tests
         run: |
@@ -38,9 +36,7 @@ jobs:
         with:
           node-version: 20
           cache: 'pnpm'
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 8
+      - run: npm install -g pnpm@8
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - name: Copy static pages


### PR DESCRIPTION
## Summary
- install pnpm 8 globally before running pnpm commands in GitHub Pages workflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890bb9f59cc8328ba8ae20ea079ebe0