### PR TITLE
chore: ignore build artifacts (docs/dist & decision-tree-app/dist)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ node_modules/
 # dependencies
 **/node_modules
 # compiled output
+docs/dist
+decision-tree-app/dist
 **/dist
 # OS or editor files
 .DS_Store


### PR DESCRIPTION
## Summary
- ignore docs/dist and decision-tree-app/dist build outputs

## Testing
- `git ls-files | grep dist`

------
https://chatgpt.com/codex/tasks/task_e_6894caa2b34c8328a2cb7704ec769814