### PR TITLE
chore(ci,pages): rebootstrap Pages workflow, simplify CI, ensure preview trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,58 +1,47 @@
--name: CI — Lint & Test (soft, no deploy)
--permissions: { contents: read }
--concurrency: { group: ci-${{ github.ref }}, cancel-in-progress: true }
--on:
--  push: { branches: [ "main" ] }
--  pull_request:
--  workflow_dispatch:
-+name: CI — Lint & Test (PR-only, soft)
-+permissions:
-+  contents: read
-+concurrency:
-+  group: ci-${{ github.ref }}
-+  cancel-in-progress: true
-+on:
-+  pull_request:
-+    paths:
-+      - 'package.json'
-+      - 'pnpm-lock.yaml'
-+      - 'decision-tree-app/**'
-+      - 'docs/**'
-+      - '.github/workflows/ci.yml'
-+  workflow_dispatch:
+name: CI - Lint & Test (PR-only, soft)
+permissions:
+  contents: read
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+on:
+  pull_request:
+    paths:
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'decision-tree-app/**'
+      - 'docs/**'
+      - '.github/**'
+  workflow_dispatch:
 
- jobs:
-   build-and-test:
-     runs-on: ubuntu-latest
-     steps:
-       - uses: actions/checkout@v4
-       - uses: actions/setup-node@v4
-         with: { node-version: '18.x', check-latest: true }
-       - uses: pnpm/action-setup@v4
-         with: { run_install: false }
-       - name: Get pnpm store path
-         id: pnpm-store
-         run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-       - uses: actions/cache@v4
-         with:
-           path: ${{ steps.pnpm-store.outputs.STORE_PATH }}
-           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-           restore-keys: ${{ runner.os }}-pnpm-
--      - name: Install workspaces (no-frozen)
-+      - name: Install workspaces (no-frozen)
-         run: |
-           pnpm -w install --no-frozen-lockfile
-           pnpm -C decision-tree-app install --no-frozen-lockfile || true
-           pnpm -C docs install --no-frozen-lockfile || true
--      - name: Lint (soft)
-+      - name: Lint (soft)
-         run: pnpm -r --if-present lint || true
-         continue-on-error: true
--      - name: Build (soft)
--        run: |
--          pnpm -C decision-tree-app run build-widget || true
--          pnpm -C docs run build || true
--      - name: Test (soft)
-+      - name: Test (soft)
-         run: pnpm -r --if-present test || true
-         continue-on-error: true
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18.x'
+          check-latest: true
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - name: Get pnpm store path
+        id: pnpm-store
+        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-
+      - name: Install workspaces (no-frozen)
+        run: |
+          pnpm -w install --no-frozen-lockfile
+          pnpm -C decision-tree-app install --no-frozen-lockfile || true
+          pnpm -C docs install --no-frozen-lockfile || true
+      - name: Lint (soft)
+        run: pnpm -r --if-present lint || true
+        continue-on-error: true
+      - name: Test (soft)
+        run: pnpm -r --if-present test || true
+        continue-on-error: true

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -61,12 +61,12 @@ jobs:
       - name: Build docs
         run: pnpm -C docs run build
 
-      - name: HOTFIX — copy static assets
+      - name: HOTFIX - copy static assets
         run: |
           rsync -a docs/images/ docs/dist/images/ || true
           rsync -a docs/js/ docs/dist/js/ || true
 
-      - name: HOTFIX — normalize base hrefs
+      - name: HOTFIX - normalize base hrefs
         run: |
           find docs/dist -name '*.html' -print0 | xargs -0 sed -i 's#<base href="/parsanaenergy/">##g'
           find docs/dist -name '*.html' -print0 | xargs -0 sed -i 's#"/parsanaenergy/#"/#g'
@@ -101,4 +101,3 @@ jobs:
         uses: actions/configure-pages@v5
       - name: Deploy PR Preview
         uses: actions/deploy-pages@v4
-

--- a/docs/index.html
+++ b/docs/index.html
@@ -269,3 +269,5 @@
   <script type="module" src="/src/main.jsx"></script>
 </body>
 </html>
+
+<!-- deploy trigger -->


### PR DESCRIPTION
- unify Pages workflow (build+deploy+PR preview)
- pnpm setup without version conflicts + pnpm store cache
- use no-frozen installs to avoid lockfile mismatch for now
- base-path fixes & CNAME in artifact; CI limited to lint/test only
- add trigger commit/file so pull_request runs fire and preview is produced