### PR TITLE
chore(docs): add minimal ESLint config for docs

### DIFF
--- a/docs/eslint.config.js
+++ b/docs/eslint.config.js
@@ -1,0 +1,11 @@
+import js from '@eslint/js'
+import { defineConfig } from 'eslint/config'
+
+export default defineConfig([
+  {
+    files: ['**/*.{js,jsx}'],
+    extends: [js.configs.recommended],
+    languageOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+    rules: {}
+  }
+])


### PR DESCRIPTION
Add a lightweight ESLint configuration for the docs workspace so CI lint stops failing.
- Uses @eslint/js recommended config
- JS/JSX only, modern ESM
- No other files modified