### PR TITLE
feat: shared typography package for monorepo

### DIFF
--- a/decision-tree-app/package.json
+++ b/decision-tree-app/package.json
@@ -12,6 +12,9 @@
     "preview": "vite preview --host"
   },
   "dependencies": {
+    "@parsana/typography": "workspace:*",
+    "@fontsource-variable/vazirmatn": "^5.0.0",
+    "@fontsource-variable/inter": "^5.0.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-markdown": "^9.1.0",

--- a/decision-tree-app/src/App.jsx
+++ b/decision-tree-app/src/App.jsx
@@ -4,6 +4,7 @@ import { Routes, Route } from 'react-router-dom';
 import Home from './pages/Home.jsx';
 import Articles from './pages/Articles.jsx';
 import Article from './pages/Article.jsx';
+import Typography from './pages/Typography.jsx';
 
 export default function App() {
   return (
@@ -13,8 +14,9 @@ export default function App() {
         <Route path="/articles" element={<Articles />} />
         <Route path="/articles/:slug" element={<Article />} />
         <Route path="/blog" element={<Articles />} />
-        <Route path="/blog/:slug" element={<Article />} />
-      </Routes>
-    </div>
-  );
-}
+          <Route path="/blog/:slug" element={<Article />} />
+          <Route path="/typography" element={<Typography />} />
+        </Routes>
+      </div>
+    );
+  }

--- a/decision-tree-app/src/main.jsx
+++ b/decision-tree-app/src/main.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App.jsx';
+import '@parsana/typography/index.css';
 import './index.css';
 
 const container = document.getElementById('root') || document.getElementById('widget-root');

--- a/decision-tree-app/src/pages/Typography.jsx
+++ b/decision-tree-app/src/pages/Typography.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+export default function Typography() {
+  return (
+    <main className="readable">
+      <h1>تیتر یک</h1>
+      <p>این یک پاراگراف نمونه برای بررسی تایپوگرافی است.</p>
+      <h2>تیتر دو</h2>
+      <p lang="en">Sample English text.</p>
+      <ul>
+        <li>گزینه اول</li>
+        <li>گزینه دوم</li>
+      </ul>
+      <table>
+        <tr><th>ستون</th><th>عدد</th></tr>
+        <tr><td>یک</td><td>۱</td></tr>
+      </table>
+      <form>
+        <input type="text" placeholder="نمونه" />
+        <button>ارسال</button>
+      </form>
+    </main>
+  );
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,6 +16,9 @@
     "terser": "^5.43.1"
   },
   "dependencies": {
+    "@parsana/typography": "workspace:*",
+    "@fontsource-variable/vazirmatn": "^5.0.0",
+    "@fontsource-variable/inter": "^5.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   }

--- a/docs/src/main.jsx
+++ b/docs/src/main.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.jsx';
+import '@parsana/typography/index.css';
 import '../css/style.min.css';
 
 const container = document.getElementById('root') || document.getElementById('widget-root');

--- a/docs/typography-preview.html
+++ b/docs/typography-preview.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <title>Typography Preview</title>
+  <link rel="stylesheet" href="/assets/css/typography.css">
+</head>
+<body class="readable">
+  <h1>تیتر یک</h1>
+  <p>این یک پاراگراف نمونه برای بررسی تایپوگرافی است.</p>
+  <h2>Heading Two</h2>
+  <p lang="en">Sample English text.</p>
+  <ul>
+    <li>گزینه اول</li>
+    <li>گزینه دوم</li>
+  </ul>
+  <table>
+    <tr><th>ستون</th><th>عدد</th></tr>
+    <tr><td>یک</td><td>۱</td></tr>
+  </table>
+  <form>
+    <input type="text" placeholder="نمونه" />
+    <button>ارسال</button>
+  </form>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "lint": "eslint \"docs/**/*.{js,jsx,ts,tsx}\" \"decision-tree-app/**/*.{js,jsx,ts,tsx}\" --max-warnings=0",
     "build:widget": "pnpm --filter decision-tree-app run build-widget",
     "build:site": "pnpm --filter docs run build",
-    "preview:dist": "pnpm -C docs preview"
+    "preview:dist": "pnpm -C docs preview",
+    "sync:typography": "node scripts/sync-typography.mjs",
+    "prebuild:docs": "pnpm sync:typography"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/packages/typography/README.md
+++ b/packages/typography/README.md
@@ -1,0 +1,13 @@
+# @parsana/typography
+
+Shared typography styles for Parsana monorepo.
+
+## Usage
+
+Install via pnpm and import the CSS:
+
+```js
+import "@parsana/typography/index.css";
+```
+
+For static HTML apps, copy `index.css` to your assets and link in `<head>`.

--- a/packages/typography/fonts.css
+++ b/packages/typography/fonts.css
@@ -1,0 +1,1 @@
+@import url("https://fonts.googleapis.com/css2?family=Vazirmatn:wdth,wght@100..125,300..800&family=Inter:wght@400;500;700&display=swap");

--- a/packages/typography/index.css
+++ b/packages/typography/index.css
@@ -1,0 +1,65 @@
+/* ===== @parsana/typography – Persian-first (RTL) base ===== */
+@import "@fontsource-variable/vazirmatn/index.css";
+@import "@fontsource-variable/inter/index.css";
+
+:root{
+  --font-sans: "Vazirmatn","Inter",system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  --leading: 1.75;
+  /* Fluid type scale */
+  --size-0: clamp(13px, 0.25vw + 12px, 14px);
+  --size-1: clamp(15px, 0.35vw + 14px, 16px); /* body */
+  --size-2: clamp(17px, 0.6vw + 14px, 19px);
+  --size-3: clamp(21px, 1vw + 16px, 25px);
+  --size-4: clamp(26px, 1.6vw + 18px, 32px);
+  --size-5: clamp(32px, 2.2vw + 20px, 40px);
+}
+
+html[lang="fa"]{ direction: rtl; }
+body{
+  font-family: var(--font-sans);
+  font-size: var(--size-1);
+  line-height: var(--leading);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  margin: 0;
+  color: #111;
+}
+
+h1,h2,h3,h4,h5,h6{
+  font-family: var(--font-sans);
+  margin: 0 0 .7em;
+  letter-spacing: normal;
+}
+h1{ font-size: var(--size-5); line-height: 1.2; font-weight: 700; }
+h2{ font-size: var(--size-4); line-height: 1.25; font-weight: 700; }
+h3{ font-size: var(--size-3); line-height: 1.3; font-weight: 600; }
+h4{ font-size: var(--size-2); line-height: 1.35; font-weight: 600; }
+
+p, li{ font-size: var(--size-1); margin: 0 0 1em; }
+a{ text-decoration: none; }
+a:hover, a:focus{ text-decoration: underline; }
+
+ul,ol{ padding-inline-start: 1.2em; margin: 0 0 1em; }
+
+table{ width: 100%; border-collapse: collapse; font-size: var(--size-0); }
+th,td{ padding: .6em .8em; border-bottom: 1px solid #eee; }
+
+input,select,textarea,button{
+  font-family: var(--font-sans);
+  font-size: var(--size-1);
+  line-height: 1.4;
+}
+
+:lang(en), code, pre, .ltr{
+  direction: ltr; unicode-bidi: isolate;
+  font-family: "Inter",system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+}
+
+p{
+  text-wrap: pretty;
+  hanging-punctuation: first allow-end;
+}
+
+.readable, article, .post-content{
+  max-width: 68ch; margin-inline: auto;
+}

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@parsana/typography",
+  "version": "0.1.0",
+  "private": false,
+  "type": "module",
+  "main": "index.css",
+  "files": ["index.css", "README.md", "fonts.css"],
+  "license": "MIT",
+  "dependencies": {
+    "@fontsource-variable/vazirmatn": "^5.0.0",
+    "@fontsource-variable/inter": "^5.0.0"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,15 @@ importers:
 
   decision-tree-app:
     dependencies:
+      '@fontsource-variable/inter':
+        specifier: ^5.0.0
+        version: 5.2.6
+      '@fontsource-variable/vazirmatn':
+        specifier: ^5.0.0
+        version: 5.2.6
+      '@parsana/typography':
+        specifier: workspace:*
+        version: link:../packages/typography
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -78,6 +87,15 @@ importers:
 
   docs:
     dependencies:
+      '@fontsource-variable/inter':
+        specifier: ^5.0.0
+        version: 5.2.6
+      '@fontsource-variable/vazirmatn':
+        specifier: ^5.0.0
+        version: 5.2.6
+      '@parsana/typography':
+        specifier: workspace:*
+        version: link:../packages/typography
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -94,6 +112,15 @@ importers:
       vite:
         specifier: ^5.0.0
         version: 5.0.0(terser@5.43.1)
+
+  packages/typography:
+    dependencies:
+      '@fontsource-variable/inter':
+        specifier: ^5.0.0
+        version: 5.2.6
+      '@fontsource-variable/vazirmatn':
+        specifier: ^5.0.0
+        version: 5.2.6
 
 packages:
 
@@ -999,6 +1026,14 @@ packages:
       '@eslint/core': 0.15.1
       levn: 0.4.1
     dev: true
+
+  /@fontsource-variable/inter@5.2.6:
+    resolution: {integrity: sha512-jks/bficUPQ9nn7GvXvHtlQIPudW7Wx8CrlZoY8bhxgeobNxlQan8DclUJuYF2loYRrGpfrhCIZZspXYysiVGg==}
+    dev: false
+
+  /@fontsource-variable/vazirmatn@5.2.6:
+    resolution: {integrity: sha512-jFH7+BjyFWbHl1VqhZ7mrWiKnPl8SH301DkaV147E3RW/gO7mJ2xvbrrNeor99XaJR2jsLHi+CUeooihY4I6oA==}
+    dev: false
 
   /@humanfs/core@0.19.1:
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - docs
   - decision-tree-app
+  - packages/*

--- a/scripts/sync-typography.mjs
+++ b/scripts/sync-typography.mjs
@@ -1,0 +1,17 @@
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+import { mkdirSync, copyFileSync } from 'fs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const src = resolve(__dirname, "../packages/typography/index.css");
+const targets = [
+  resolve(__dirname, "../docs/assets/css/typography.css")
+];
+
+for (const t of targets) {
+  mkdirSync(dirname(t), { recursive: true });
+  copyFileSync(src, t);
+  console.log("Synced:", t);
+}


### PR DESCRIPTION
## Summary
- add `@parsana/typography` package with Vazirmatn and Inter variable fonts and RTL-friendly base styles
- wire typography styles into docs and decision-tree-app; add preview pages
- include sync script for copying shared CSS into static assets

## Testing
- `pnpm --filter docs build`
- `pnpm --filter decision-tree-app build`
- `pnpm --filter docs lint` *(fails: "ESLint couldn't find an eslint.config.(js|mjs|cjs) file" and numerous `no-undef` errors)*
- `pnpm --filter decision-tree-app lint`


------
https://chatgpt.com/codex/tasks/task_e_689604e9ada083288e26fa0b7f80ebbd