### PR TITLE
feat(articles): detail page from markdown (monthly-generator-pm-checklist)

### DIFF
--- a/docs/articles/monthly-generator-pm-checklist/index.html
+++ b/docs/articles/monthly-generator-pm-checklist/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>چک لیست سرویس ماهانه ژنراتور</title>
+  <link rel="canonical" href="https://parsanaenergy.ir/articles/monthly-generator-pm-checklist/" />
+  <meta property="og:title" content="چک لیست سرویس ماهانه ژنراتور" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://parsanaenergy.ir/articles/monthly-generator-pm-checklist/" />
+  <meta property="og:image" content="/images/articles/monthly-generator-pm-checklist.webp" />
+  <link rel="stylesheet" href="/css/style.min.css" />
+  <link rel="stylesheet" href="/assets/articles-style.css" />
+</head>
+<body>
+  <main class="article">
+    <h1>چک لیست سرویس ماهانه ژنراتور</h1>
+    <div class="article-meta">2025-08-08 · Parsana Energy · 1 دقیقه مطالعه</div>
+    <img src="/images/articles/monthly-generator-pm-checklist.webp" alt="چک لیست سرویس ماهانه ژنراتور" class="article-cover" loading="lazy" width="1200" height="675" />
+    <div class="article-content"><p>در این مقاله به مواردی که باید در سرویس ماهانه ژنراتورها بررسی شود می‌پردازیم.</p>
+<ol>
+<li>بررسی سطح روغن و فیلترها</li>
+<li>چک کردن اتصالات و کابل‌ها</li>
+<li>تست عملکرد بدون بار</li>
+</ol>
+<p>امیدواریم این راهنما به نگهداری بهتر ژنراتور شما کمک کند.</p></div><p><a href="/articles/">بازگشت به مقالات</a></p>
+  </main>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "چک لیست سرویس ماهانه ژنراتور",
+    "datePublished": "2025-08-08",
+    "author": {
+      "@type": "Organization",
+      "name": "Parsana Energy"
+    },
+    "image": "/images/articles/monthly-generator-pm-checklist.webp",
+    "mainEntityOfPage": "https://parsanaenergy.ir/articles/monthly-generator-pm-checklist/"
+  }
+  </script>
+</body>
+</html>

--- a/docs/articles/posts.json
+++ b/docs/articles/posts.json
@@ -12,7 +12,7 @@
       "چک‌لیست"
     ],
     "excerpt": "در این مقاله به مواردی که باید در سرویس ماهانه ژنراتورها بررسی شود می‌پردازیم…",
-    "cover": "TODO",
+    "cover": "/images/articles/monthly-generator-pm-checklist.webp",
     "author": {
       "name": "Parsana Energy"
     },

--- a/scripts/generate-articles.mjs
+++ b/scripts/generate-articles.mjs
@@ -1,0 +1,81 @@
+import fs from 'fs';
+import path from 'path';
+
+const postsPath = path.join('docs', 'articles', 'posts.json');
+const posts = JSON.parse(fs.readFileSync(postsPath, 'utf8'));
+const template = fs.readFileSync(path.join('tools', 'templates', 'article.html'), 'utf8');
+
+function markdownToHtml(md) {
+  const lines = md.split(/\r?\n/);
+  const html = [];
+  let inUl = false;
+  let inOl = false;
+  const closeLists = () => {
+    if (inUl) { html.push('</ul>'); inUl = false; }
+    if (inOl) { html.push('</ol>'); inOl = false; }
+  };
+  for (let line of lines) {
+    if (!line.trim()) { closeLists(); continue; }
+    const headingMatch = line.match(/^(#{1,6})\s+(.*)$/);
+    if (headingMatch) {
+      closeLists();
+      const level = headingMatch[1].length;
+      html.push(`<h${level}>${headingMatch[2]}</h${level}>`);
+      continue;
+    }
+    const olMatch = line.match(/^\d+\.\s+(.*)$/);
+    if (olMatch) {
+      if (!inOl) { closeLists(); html.push('<ol>'); inOl = true; }
+      html.push(`<li>${olMatch[1]}</li>`);
+      continue;
+    }
+    const ulMatch = line.match(/^[-*]\s+(.*)$/);
+    if (ulMatch) {
+      if (!inUl) { closeLists(); html.push('<ul>'); inUl = true; }
+      html.push(`<li>${ulMatch[1]}</li>`);
+      continue;
+    }
+    closeLists();
+    html.push(`<p>${line}</p>`);
+  }
+  closeLists();
+  return html.join('\n');
+}
+
+posts.forEach((post, index) => {
+  const slug = post.slug;
+  const mdPath = path.join('docs', 'public', 'articles', `${slug}.md`);
+  const rawMd = fs.readFileSync(mdPath, 'utf8');
+  const mdLines = rawMd.split(/\r?\n/);
+  if (mdLines[0] && mdLines[0].startsWith('#')) {
+    mdLines.shift();
+  }
+  const bodyHtml = markdownToHtml(mdLines.join('\n'));
+
+  const canonical = post.canonical || `https://parsanaenergy.ir/articles/${slug}/`;
+  const cover = post.cover === 'TODO' ? `/images/articles/${slug}.webp` : post.cover;
+
+  const prev = posts[index - 1];
+  const next = posts[index + 1];
+  let navHtml = '';
+  if (prev || next) {
+    navHtml += '<nav class="article-nav">';
+    if (prev) navHtml += `<a class="prev" href="/articles/${prev.slug}/">قبلی: ${prev.title}</a>`;
+    if (next) navHtml += `<a class="next" href="/articles/${next.slug}/">بعدی: ${next.title}</a>`;
+    navHtml += '</nav>';
+  }
+  navHtml += '<p><a href="/articles/">بازگشت به مقالات</a></p>';
+  const content = `<div class="article-content">${bodyHtml}</div>${navHtml}`;
+
+  const html = template
+    .replace(/{{title}}/g, post.title)
+    .replace(/{{date}}/g, post.date)
+    .replace(/{{readingTime}}/g, post.readingTime)
+    .replace(/{{cover}}/g, cover)
+    .replace(/{{content}}/g, content)
+    .replace(/{{canonical}}/g, canonical);
+
+  const outDir = path.join('docs', 'articles', slug);
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(path.join(outDir, 'index.html'), html);
+});

--- a/tools/templates/article.html
+++ b/tools/templates/article.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{{title}}</title>
+  <link rel="canonical" href="{{canonical}}" />
+  <meta property="og:title" content="{{title}}" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="{{canonical}}" />
+  <meta property="og:image" content="{{cover}}" />
+  <link rel="stylesheet" href="/css/style.min.css" />
+  <link rel="stylesheet" href="/assets/articles-style.css" />
+</head>
+<body>
+  <main class="article">
+    <h1>{{title}}</h1>
+    <div class="article-meta">{{date}} · Parsana Energy · {{readingTime}} دقیقه مطالعه</div>
+    <img src="{{cover}}" alt="{{title}}" class="article-cover" loading="lazy" width="1200" height="675" />
+    {{content}}
+  </main>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "{{title}}",
+    "datePublished": "{{date}}",
+    "author": {
+      "@type": "Organization",
+      "name": "Parsana Energy"
+    },
+    "image": "{{cover}}",
+    "mainEntityOfPage": "{{canonical}}"
+  }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add reusable article template with SEO and JSON-LD placeholders
- script to convert markdown posts into article detail pages with prev/next navigation
- generate monthly generator PM checklist page from markdown and update post cover

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm --prefix docs run lint` *(fails: 466 errors, l and others defined but never used etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6896284706648328af043d6c72da23f9