### PR TITLE
fix(articles): correct asset paths, run blog generators on build, CSP-safe (no binary files)

### DIFF
--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -7,20 +7,20 @@
   <meta name="description" content="مشاوره، فروش و اجاره تجهیزات برق اضطراری و انرژی خورشیدی">
   <link rel="canonical" href="https://parsanaenergy.ir/articles/">
   <meta http-equiv="Strict-Transport-Security" content="max-age=63072000; includeSubDomains; preload">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'">
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta http-equiv="Referrer-Policy" content="same-origin">
   <meta property="og:title" content="وبلاگ پارسانا انرژی">
   <meta property="og:description" content="مشاوره، فروش و اجاره تجهیزات برق اضطراری و انرژی خورشیدی">
   <meta property="og:url" content="https://parsanaenergy.ir/articles/">
   <meta property="og:type" content="website">
-  <meta property="og:image" content="../images/logo.png?v=ARTICLES-1">
+  <meta property="og:image" content="../images/logo.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="وبلاگ پارسانا انرژی">
   <meta name="twitter:description" content="مشاوره، فروش و اجاره تجهیزات برق اضطراری و انرژی خورشیدی">
-  <meta name="twitter:image" content="../images/logo.png?v=ARTICLES-1">
-  <link rel="stylesheet" href="/css/style.min.css">
-  <link rel="stylesheet" href="/assets/articles-style.css">
+  <meta name="twitter:image" content="../images/logo.png">
+  <link rel="stylesheet" href="../assets/css/site.css?v=ART1">
+  <link rel="stylesheet" href="../assets/articles-style.css?v=ART1">
 </head>
 <body>
   <div class="top-bar">
@@ -31,7 +31,7 @@
 
   <div class="sticky-header">
     <a href="/" class="header-logo">
-      <img src="../images/logo.png?v=ARTICLES-1" alt="Parsana Energy logo">
+        <img src="../images/logo.png" alt="Parsana Energy logo">
     </a>
     <input type="checkbox" id="menu-toggle" class="menu-toggle" />
     <label for="menu-toggle" class="hamburger">
@@ -100,7 +100,7 @@
     </div>
   </footer>
 
-  <script src="/js/articles.min.js"></script>
-  <script src="/js/main.min.js"></script>
+  <script src="../assets/articles.min.js?v=ART1"></script>
+  <script src="../assets/main.min.js?v=ART1"></script>
 </body>
 </html>

--- a/docs/articles/monthly-generator-pm-checklist/index.html
+++ b/docs/articles/monthly-generator-pm-checklist/index.html
@@ -3,20 +3,21 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>چک لیست سرویس ماهانه ژنراتور</title>
-  <link rel="canonical" href="https://parsanaenergy.ir/articles/monthly-generator-pm-checklist/" />
-  <meta property="og:title" content="چک لیست سرویس ماهانه ژنراتور" />
-  <meta property="og:type" content="article" />
-  <meta property="og:url" content="https://parsanaenergy.ir/articles/monthly-generator-pm-checklist/" />
-  <meta property="og:image" content="../../images/generator-maintenance-check.jpg?v=ARTICLES-1" />
-  <link rel="stylesheet" href="/css/style.min.css" />
-  <link rel="stylesheet" href="/assets/articles-style.css" />
+    <title>چک لیست سرویس ماهانه ژنراتور</title>
+    <link rel="canonical" href="https://parsanaenergy.ir/articles/monthly-generator-pm-checklist/" />
+    <meta property="og:title" content="چک لیست سرویس ماهانه ژنراتور" />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://parsanaenergy.ir/articles/monthly-generator-pm-checklist/" />
+    <meta property="og:image" content="../../images/generator-maintenance-check.jpg" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'" />
+    <link rel="stylesheet" href="../../assets/css/site.css?v=ART1" />
+    <link rel="stylesheet" href="../../assets/articles-style.css?v=ART1" />
 </head>
 <body>
   <main class="article">
     <h1>چک لیست سرویس ماهانه ژنراتور</h1>
     <div class="article-meta">2025-08-09 · Parsana Energy · 1 دقیقه مطالعه</div>
-    <img src="../../images/generator-maintenance-check.jpg?v=ARTICLES-1" alt="چک لیست سرویس ماهانه ژنراتور" class="article-cover" loading="lazy" width="1200" height="675" />
+      <img src="../../images/generator-maintenance-check.jpg" alt="چک لیست سرویس ماهانه ژنراتور" class="article-cover" loading="lazy" width="1200" height="675" />
     <div class="article-content"><p>در این مقاله به مواردی که باید در سرویس ماهانه ژنراتورها بررسی شود می‌پردازیم.</p>
 <ol>
 <li>بررسی سطح روغن و فیلترها</li>

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "prebuild": "node ../scripts/sync-images.mjs && node ../scripts/generate-posts.mjs && node ../scripts/generate-articles.mjs && terser js/articles.js -o js/articles.min.js --compress --mangle --toplevel",
+    "prebuild": "node ../scripts/sync-images.mjs && node ../scripts/generate-posts.mjs && node ../scripts/generate-articles.mjs && node ../scripts/minify-articles.mjs",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview --host",

--- a/docs/public/.gitignore
+++ b/docs/public/.gitignore
@@ -1,0 +1,2 @@
+assets/
+images/

--- a/scripts/minify-articles.mjs
+++ b/scripts/minify-articles.mjs
@@ -1,0 +1,17 @@
+import { cp, mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+const articlesSrc = 'docs/js/articles.js';
+const mainSrc = 'docs/js/main.min.js';
+const destDir = 'docs/public/assets';
+
+await mkdir(destDir, { recursive: true });
+
+if (existsSync(articlesSrc)) {
+  await cp(articlesSrc, path.join(destDir, 'articles.min.js'));
+}
+
+if (existsSync(mainSrc)) {
+  await cp(mainSrc, path.join(destDir, 'main.min.js'));
+}


### PR DESCRIPTION
## Summary
- copy article and core scripts into `docs/public/assets` during prebuild
- run image + article/post generators before `vite build`
- fix `/articles` pages to use relative asset paths with CSP-safe headers

## Testing
- `./scripts/verify-docs-build.sh`


------
https://chatgpt.com/codex/tasks/task_e_6896df257f6c8328bd5275eb6fc3d0c1