### PR TITLE
fix(articles): copy article styles to /assets and verify in build

### DIFF
--- a/scripts/minify-articles.mjs
+++ b/scripts/minify-articles.mjs
@@ -1,4 +1,4 @@
-import { cp, mkdir } from 'node:fs/promises';
+import { cp, mkdir, readdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 
@@ -14,4 +14,14 @@ if (existsSync(articlesSrc)) {
 
 if (existsSync(mainSrc)) {
   await cp(mainSrc, path.join(destDir, 'main.min.js'));
+}
+
+// NEW: copy all article styles into public assets
+const cssDir = 'docs/assets';
+if (existsSync(cssDir)) {
+  const files = await readdir(cssDir);
+  const cssList = files.filter(f => /^articles-style.*\.css$/i.test(f));
+  for (const f of cssList) {
+    await cp(path.join(cssDir, f), path.join(destDir, f));
+  }
 }

--- a/scripts/verify-docs-build.sh
+++ b/scripts/verify-docs-build.sh
@@ -37,7 +37,14 @@ for file in "${required_files[@]}"; do
 done
 
 if [[ ${#missing[@]} -eq 0 ]]; then
-  echo "✅ All required files exist."
+  # extra: ensure CSS for articles exists
+  shopt -s nullglob
+  css=(docs/dist/assets/articles-style*.css)
+  if (( ${#css[@]} == 0 )); then
+    echo "❌ Missing articles CSS in docs/dist/assets/"
+    exit 1
+  fi
+  echo "✅ All required files exist (including articles CSS)."
 else
   echo "❌ Missing files:"
   for f in "${missing[@]}"; do


### PR DESCRIPTION
## Summary
- copy article CSS files into `/assets` along with article and main scripts
- extend docs build verifier to check for articles CSS output

## Testing
- `pnpm i -w`
- `pnpm --filter docs run clean || true`
- `pnpm --filter docs run build`
- `node scripts/minify-articles.mjs`
- `pnpm --filter docs run build`
- `bash scripts/verify-docs-build.sh`
- `ls docs/public/assets`
- `ls docs/dist/assets | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6898141a295883288d460356097b074b