### PR TITLE
Add article guard and run before pages build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -63,6 +63,9 @@ jobs:
         id: pages
         uses: actions/configure-pages@v5
 
+      - name: Guard articles
+        run: bash scripts/guard-articles.sh
+
       - name: Build docs (Vite)
         run: |
           pnpm -C docs run build -- --base="${{ steps.pages.outputs.base_path }}/"

--- a/scripts/guard-articles.sh
+++ b/scripts/guard-articles.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure docs/articles/posts.json exists
+if [[ ! -f "docs/articles/posts.json" ]]; then
+  echo "❌ Missing docs/articles/posts.json" >&2
+  exit 1
+fi
+
+# Ensure at least one page exists in docs/articles (excluding posts.json and index.html)
+if ! find "docs/articles" -mindepth 1 -maxdepth 1 ! -name 'posts.json' ! -name 'index.html' | grep -q .; then
+  echo "❌ No article pages found in docs/articles" >&2
+  exit 1
+fi
+
+# Ensure articles index page exists either in docs/articles or docs/public/articles
+if [[ ! -f "docs/articles/index.html" && ! -f "docs/public/articles/index.html" ]]; then
+  echo "❌ Missing articles index page (docs/articles/index.html or docs/public/articles/index.html)" >&2
+  exit 1
+fi
+
+echo "✅ Article guards passed" 


### PR DESCRIPTION
## Summary
- add guard-articles.sh to verify article data and index
- run guard-articles.sh in Pages workflow before building docs

## Testing
- `bash scripts/guard-articles.sh`
- `pnpm lint` *(fails: ESLint couldn't find eslint.config.(js|mjs|cjs))*

------
https://chatgpt.com/codex/tasks/task_e_6898301d3b34832889ec07e643f88dc5