### PR TITLE
feat(header): Awatt-like header

### DIFF
--- a/docs/css/header-awatt.css
+++ b/docs/css/header-awatt.css
@@ -1,0 +1,63 @@
+/* Header Awatt-like */
+:root { --brand: #16A34A; --ink:#223354; --bg:#F6F7F8; }
+.header {
+  background: var(--bg);
+  border-bottom: 1px solid #eaeaea;
+  position: sticky; top:0; z-index: 1000;
+  font-family: 'Vazirmatn', sans-serif;
+}
+.header-bar {
+  max-width: 1200px; margin: 0 auto; padding: 10px 16px;
+  display: grid; grid-template-columns: 1fr 2fr 1fr; gap: 16px; align-items: center;
+}
+.brand { display:flex; align-items:center; justify-content:flex-end; gap:.75rem; }
+.brand img { width:48px; height:48px; border-radius:50%; }
+.brand .name { font-weight:700; font-size:1.1rem; }
+.brand .tagline { font-size:.9rem; color:#666; }
+.search {
+  background:#fff; border:1px solid #e5e5e5; border-radius:10px;
+  display:flex; align-items:center; padding:6px 10px; box-shadow: 0 2px 6px rgba(0,0,0,.05);
+}
+.search input {
+  flex:1; border:none; outline:none; font-family: inherit; direction: rtl; padding:6px;
+}
+.social { display:flex; align-items:center; gap:10px; justify-content:flex-start; }
+.social a svg { width:22px; height:22px; fill:#000; opacity:.85; transition:opacity .2s }
+.social a:hover svg { opacity:1; }
+.call {
+  position: relative; margin-right:8px;
+}
+.call .btn {
+  background: var(--brand); color:#fff; padding:10px 14px; border-radius:14px;
+  box-shadow: 0 6px 14px rgba(22,163,74,.25); font-weight:700;
+}
+.call .panel {
+  position:absolute; right:0; top:110%; width:210px; background:#fff; border:1px solid #eee;
+  border-radius:14px; box-shadow:0 10px 24px rgba(0,0,0,.12); padding:12px; display:none;
+}
+.call.open .panel { display:block; }
+.navbar {
+  background:#fff; margin-top:8px; border-radius:14px; box-shadow:0 8px 20px rgba(0,0,0,.08);
+}
+.navbar-inner { max-width:1200px; margin:0 auto; padding:10px 16px; }
+.nav-list { display:flex; gap:24px; justify-content:flex-end; align-items:center; }
+.nav-list a { color: var(--ink); text-decoration:none; padding:8px 6px; position:relative; }
+.nav-list a.active::after {
+  content:""; position:absolute; left:0; right:0; bottom:-6px; height:3px; background:var(--ink); border-radius:4px;
+}
+/* Dropdown */
+.dropdown { position:relative; }
+.dropdown-menu {
+  position:absolute; right:0; top:120%; background:#fff; border:1px solid #eee; border-radius:10px;
+  box-shadow:0 10px 24px rgba(0,0,0,.12); min-width:220px; display:none; padding:8px;
+}
+.dropdown.open .dropdown-menu { display:block; }
+.dropdown-menu a { display:block; padding:10px 12px; color:#333; border-radius:8px; }
+.dropdown-menu a:hover { background:#f3f4f6; }
+/* Responsive */
+@media (max-width: 992px){
+  .header-bar { grid-template-columns: 1fr; gap:10px; }
+  .brand { justify-content:center; }
+  .social { justify-content:center; }
+  .nav-list { flex-wrap:wrap; gap:12px; justify-content:center; }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -22,36 +22,63 @@
   <link rel="icon" href="/images/favicon.ico" />
   <link rel="stylesheet" href="assets/css/site-a4c0b310.css" />
   <!-- استایل اصلی سفارشی سایت -->
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Vazirmatn:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/css/header-awatt.css">
+  <script type="module" src="/js/header-awatt.js"></script>
 </head>
   <body>
 
-    <div class="top-bar">
-      <span class="phone"><i class="fa fa-phone"></i>  تماس :۰۹۱۵۰۱۰۰۶۳۳ </span>
-      <span class="email"><i class="fa fa-envelope"></i> info@parsana-energy.ir</span>
-      <span class="hours"><i class="fa fa-clock"></i> 8:00-18:00</span>
-    </div>
-
-    <div class="sticky-header">
-      <a href="index.html" class="header-logo">
-        <img src="images/logo.png" alt="Parsana Energy logo" />
+<header class="header" dir="rtl">
+  <div class="header-bar">
+    <div class="social">
+      <a href="https://t.me/..." aria-label="Telegram">
+        <svg viewBox="0 0 24 24"><path d="M9.9 16.2l-.4 5.7c.6 0 .8-.2 1.1-.5l2.6-2.5 5.4 4c1 .6 1.6.3 1.9-.9l3.5-16.4v0c.3-1.3-.5-1.8-1.5-1.5L1.8 9.6c-1.2.4-1.2 1.1-.2 1.4l5.6 1.7L18.9 6c.6-.4 1.1-.2.6.2"/></svg>
       </a>
-      <input type="checkbox" id="menu-toggle" class="menu-toggle" />
-      <label for="menu-toggle" class="hamburger">
-        <span></span>
-      </label>
-      <nav>
-        <ul class="nav-menu">
-          <li><a href="index.html">خانه</a></li>
-          <li><a href="#services">خدمات</a></li>
-          <li><a href="#projects">پروژه‌ها</a></li>
-          <li><a href="records/index.html">سوابق</a></li>
-          <li><a href="/articles/">مقالات</a></li>
-          <li><a href="catalog/catalog.html">کاتالوگ</a></li>
-          <li><a href="#contact">تماس با ما</a></li>
-        </ul>
-      </nav>
+      <a href="https://instagram.com/..." aria-label="Instagram">
+        <svg viewBox="0 0 24 24"><path d="M7 2h10a5 5 0 0 1 5 5v10a5 5 0 0 1-5 5H7a5 5 0 0 1-5-5V7a5 5 0 0 1 5-5zm5 5a5 5 0 1 0 0 10 5 5 0 0 0 0-10zm6.5-.8a1.2 1.2 0 1 0 0 2.4 1.2 1.2 0 0 0 0-2.4z"/></svg>
+      </a>
+      <div class="call">
+        <a href="#" class="btn">تماس سریع</a>
+        <div class="panel">
+          <div>۰۵۱۳۵۳۵۰۳۰۶</div>
+          <div>۰۹۱۵۰۱۰۰۶۳۳</div>
+        </div>
+      </div>
     </div>
 
+    <div class="search" role="search">
+      <svg viewBox="0 0 24 24" width="20" height="20"><path d="M10 2a8 8 0 105.3 14l4.4 4.4 1.4-1.4-4.4-4.4A8 8 0 0010 2zm0 2a6 6 0 110 12 6 6 0 010-12z"/></svg>
+      <input type="search" placeholder="جستجو کنید..." aria-label="جستجو">
+    </div>
+
+    <div class="brand">
+      <div>
+        <div class="name">پارسـانا انرژی</div>
+        <div class="tagline">تأمین برق پایدار</div>
+      </div>
+      <img src="/images/logo.png" alt="Parsana Energy">
+    </div>
+  </div>
+
+  <nav class="navbar" aria-label="Main">
+    <div class="navbar-inner">
+      <ul class="nav-list">
+        <li><a href="/" data-path="/">صفحه اصلی</a></li>
+        <li class="dropdown">
+          <a href="/services/" data-path="/services/" aria-haspopup="true" aria-expanded="false">خدمات ما</a>
+          <div class="dropdown-menu" role="menu">
+            <a href="/services/genset/">ژنراتور و برق اضطراری</a>
+            <a href="/services/solar/">نیروگاه خورشیدی</a>
+          </div>
+        </li>
+        <li><a href="/articles/" data-path="/articles/">مقالات</a></li>
+        <li><a href="/about/" data-path="/about/">درباره ما</a></li>
+        <li><a href="/contact/" data-path="/contact/">تماس با ما</a></li>
+      </ul>
+    </div>
+  </nav>
+</header>
   <!-- ===== Hero ===== -->
   <header id="hero">
     <div class="hero-content">

--- a/docs/js/header-awatt.js
+++ b/docs/js/header-awatt.js
@@ -1,0 +1,21 @@
+(function(){
+  // toggle call panel
+  const call = document.querySelector('.call');
+  if (call) {
+    const btn = call.querySelector('.btn');
+    btn?.addEventListener('click', (e)=>{ e.preventDefault(); call.classList.toggle('open'); });
+    document.addEventListener('click', (e)=>{ if(!call.contains(e.target)) call.classList.remove('open'); });
+  }
+  // dropdown for "خدمات"
+  document.querySelectorAll('.dropdown').forEach(dd=>{
+    const toggle = dd.querySelector('a[aria-haspopup="true"]');
+    toggle?.addEventListener('click', (e)=>{ e.preventDefault(); dd.classList.toggle('open'); });
+    document.addEventListener('click', (e)=>{ if(!dd.contains(e.target)) dd.classList.remove('open'); });
+  });
+  // mark active by pathname (simple)
+  const path = location.pathname.replace(/\/+$/,'');
+  document.querySelectorAll('.nav-list a[data-path]').forEach(a=>{
+    const p = a.getAttribute('data-path').replace(/\/+$/,'');
+    if (p && p === path) a.classList.add('active');
+  });
+})();


### PR DESCRIPTION
## Summary
- add Awatt-style header layout and branding
- implement header interactions and active nav highlighting
- inject Awatt header into landing page with Vazirmatn font

## Testing
- `pnpm i -w`
- `pnpm --filter docs run build`
- `pnpm --filter docs run preview -- --host` *(failed: process stopped, then relaunched in separate session)*


------
https://chatgpt.com/codex/tasks/task_e_6898432a7fb08328a7a837acb155c408