### PR TITLE
chore(eslint): add safe config + non-blocking CI lint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,11 @@
+node_modules/
+dist/
+build/
+.next/
+out/
+coverage/
+public/vendor/
+gh-pages/
+docs/dist/
+docs/assets/
+docs/widget/assets/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Lint (non-blocking)
+        run: pnpm lint || true
+
       - name: Prebuild
         run: pnpm -r run prebuild
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,54 @@
+// @ts-check
+import js from '@eslint/js'
+import globals from 'globals'
+import react from 'eslint-plugin-react'
+import reactHooks from 'eslint-plugin-react-hooks'
+import eslintConfigPrettier from 'eslint-config-prettier'
+
+/** @type {import('eslint').Linter.FlatConfig[]} */
+export default [
+  { ignores: ['node_modules/**','dist/**','build/**','.next/**','out/**','coverage/**','public/vendor/**','gh-pages/**','docs/dist/**','docs/assets/**','docs/widget/assets/**'] },
+
+  js.configs.recommended,
+
+  {
+    files: ['**/*.{js,jsx,ts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+      },
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+        ...globals.jest,
+      },
+    },
+    rules: {
+      'no-unused-vars': 'warn',
+      'no-undef': 'warn',
+    },
+  },
+
+  {
+    files: ['**/*.{jsx,tsx}'],
+    plugins: { react, 'react-hooks': reactHooks },
+    rules: {
+      'react/jsx-uses-react': 'off',
+      'react/react-in-jsx-scope': 'off',
+    },
+    settings: { react: { version: 'detect' } },
+  },
+
+  {
+    files: ['**/*.test.*', '**/*.spec.*', '**/__tests__/**'],
+    rules: {
+      'no-unused-expressions': 'off',
+      'no-unused-vars': 'off',
+      'no-undef': 'off',
+    },
+  },
+
+  { rules: { ...eslintConfigPrettier.rules } },
+]

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
+    "globals": "^16.3.0",
     "terser": "^5.43.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^5.2.0
         version: 5.2.0(eslint@9.30.1)
+      globals:
+        specifier: ^16.3.0
+        version: 16.3.0
       terser:
         specifier: ^5.43.1
         version: 5.43.1


### PR DESCRIPTION
## Summary
- configure ESLint with React and Prettier support
- ignore build artifacts and add safe test overrides
- run lint in deploy workflow without blocking the build

## Testing
- `pnpm -v`
- `pnpm lint || echo "lint warnings only"`


------
https://chatgpt.com/codex/tasks/task_e_68984988a9288328a7a02adda0bde9d5