### PR TITLE
chore: ensure docs articles directory in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,8 +30,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Prebuild
-        run: pnpm -r run prebuild
+      - name: Ensure articles directory exists
+        working-directory: docs
+        run: mkdir -p docs/public/articles
+
+      - name: Docs Prebuild
+        working-directory: docs
+        run: pnpm node ../scripts/sync-images.mjs && pnpm node ../scripts/generate-posts.mjs && pnpm node ../scripts/generate-articles.mjs && pnpm node ../scripts/minify-articles.mjs
 
       - name: Guard articles
         run: bash scripts/guard-articles.sh


### PR DESCRIPTION
## Summary
- create articles directory before prebuild step
- run docs prebuild commands explicitly

## Testing
- `pnpm lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `cd docs && mkdir -p docs/public/articles && pnpm node ../scripts/sync-images.mjs && pnpm node ../scripts/generate-posts.mjs && pnpm node ../scripts/generate-articles.mjs && pnpm node ../scripts/minify-articles.mjs` *(fails: ENOENT: no such file or directory, open 'tools/templates/article.html')*


------
https://chatgpt.com/codex/tasks/task_e_68984b868390832880946be464a2a464