### PR TITLE
refactor(articles): generate to src and import from src; fix build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,6 @@ jobs:
       - name: Install root deps
         run: pnpm install --frozen-lockfile=false
 
-      # جلوگیری از ENOENT
-      - name: Ensure prebuild dirs
-        run: mkdir -p docs/public/articles
-
       # اجرای prebuildها از ریشه
       - name: Run prebuild scripts
         run: |

--- a/decision-tree-app/src/pages/Article.jsx
+++ b/decision-tree-app/src/pages/Article.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { getArticle } from '../../../docs/public/articles/index.js';
+import articles from '../../../docs/src/data/articles.js';
 import ReactMarkdown from 'react-markdown';
 
 const Article = () => {
   const { slug } = useParams();
-  const article = getArticle(slug);
+  const article = articles.find(a => a.slug === slug);
 
   if (!article) {
     return (

--- a/decision-tree-app/src/pages/Articles.jsx
+++ b/decision-tree-app/src/pages/Articles.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { articles } from '../../../docs/public/articles/index.js';
+import articles from '../../../docs/src/data/articles.js';
 
 const Articles = () => (
   <main className="articles-list">

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "prebuild": "pnpm node ../scripts/sync-images.mjs && pnpm node ../scripts/generate-posts.mjs && pnpm node ../scripts/generate-articles.mjs && pnpm node ../scripts/minify-articles.mjs",
+    "prebuild": "pnpm --dir .. exec node scripts/sync-images.mjs && pnpm --dir .. exec node scripts/generate-posts.mjs && pnpm --dir .. exec node scripts/generate-articles.mjs && pnpm --dir .. exec node scripts/minify-articles.mjs",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview --host",

--- a/docs/src/data/articles.js
+++ b/docs/src/data/articles.js
@@ -1,0 +1,1 @@
+export default [];

--- a/scripts/cf-build.sh
+++ b/scripts/cf-build.sh
@@ -24,9 +24,6 @@ node -v || true
 echo "==> Installing root deps (if any)"
 pnpm install --frozen-lockfile=false || true
 
-# دایرکتوری‌های موردنیاز برای prebuild
-mkdir -p docs/public/articles
-
 echo "==> Running prebuild scripts from repo root"
 # از Node ریشه صدا بزن که مسیرها درست باشه
 pnpm node scripts/sync-images.mjs

--- a/scripts/guard-articles.sh
+++ b/scripts/guard-articles.sh
@@ -13,9 +13,9 @@ if ! find "docs/articles" -mindepth 1 -maxdepth 1 ! -name 'posts.json' ! -name '
   exit 1
 fi
 
-# Ensure articles index page exists either in docs/articles or docs/public/articles
-if [[ ! -f "docs/articles/index.html" && ! -f "docs/public/articles/index.html" ]]; then
-  echo "❌ Missing articles index page (docs/articles/index.html or docs/public/articles/index.html)" >&2
+# Ensure articles index page exists in docs/articles
+if [[ ! -f "docs/articles/index.html" ]]; then
+  echo "❌ Missing articles index page (docs/articles/index.html)" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- generate article data to docs/src/data/articles.js with fallback []
- import articles from src in Article pages
- remove unused docs/public/articles references and run prebuild before build

## Testing
- `pnpm node scripts/sync-images.mjs`
- `pnpm node scripts/generate-posts.mjs`
- `pnpm node scripts/generate-articles.mjs`
- `pnpm node scripts/minify-articles.mjs || true`
- `pnpm -C docs install --frozen-lockfile=false`
- `pnpm -C docs run build`


------
https://chatgpt.com/codex/tasks/task_e_6898cdac8534832887c9cd40b0992be8