### PR TITLE
chore(build): add build:widget and chain prebuild→build; make local build one-shot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,12 @@ jobs:
       - name: Install root deps
         run: pnpm install --frozen-lockfile=false
 
+      # Build decision-tree widget and verify assets
+      - name: Build widget
+        run: pnpm run build:widget
+      - name: Verify widget build output
+        run: pnpm node scripts/verify-widget-build.mjs
+
       # اجرای prebuildها از ریشه
       - name: Run prebuild scripts
         run: |

--- a/decision-tree-app/build-widget.sh
+++ b/decision-tree-app/build-widget.sh
@@ -1,18 +1,20 @@
 #!/bin/bash
 
-# Build the decision-tree-app and copy the output to docs/widget
+# Build script to copy decision-tree widget output to docs/public widgets directory
 set -e
 
-# Dependencies are installed via pnpm-workspace at the repo root
-pnpm run build
+DEST_DIR="../docs/public/widgets/decision-tree"
 
-# Replace docs/widget contents with the new build
-mkdir -p ../docs/widget/assets
-rm -f ../docs/widget/assets/*
-cp dist/assets/* ../docs/widget/assets/
-cp dist/index.html ../docs/widget/index.html
+# Ensure destination directories exist
+mkdir -p "$DEST_DIR/assets"
+
+# Replace existing assets with new build
+rm -f "$DEST_DIR/assets"/*
+cp dist/assets/* "$DEST_DIR/assets/"
+cp dist/index.html "$DEST_DIR/index.html"
 
 # Update HTML references with new hashed filenames
-node ../scripts/update-html-hashes.js dist ../docs/widget/index.html
+node ../scripts/update-html-hashes.js dist "$DEST_DIR/index.html"
 
-echo "✅ build completed and files copied to docs/widget"
+echo "✅ build completed and files copied to $DEST_DIR"
+

--- a/decision-tree-app/package.json
+++ b/decision-tree-app/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite --host",
     "build": "vite build",
-    "build-widget": "vite build && mkdir -p ../docs/widget && cp -r dist/* ../docs/widget/",
+    "build-widget": "vite build && bash ./build-widget.sh",
     "lint": "eslint \"**/*.{js,jsx,ts,tsx}\" --max-warnings=0",
     "preview": "vite preview --host"
   },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "node": ">=18"
   },
   "scripts": {
-    "build": "pnpm --filter ./docs... run build"
+    "build:widget": "pnpm --filter decision-tree-app run build-widget",
+    "prebuild": "pnpm run build:widget && pnpm node scripts/sync-images.mjs && pnpm node scripts/generate-posts.mjs && pnpm node scripts/generate-articles.mjs && pnpm node scripts/minify-articles.mjs",
+    "build": "pnpm run prebuild && pnpm -C docs run build",
+    "test:widget-build": "node scripts/verify-widget-build.mjs"
   }
 }

--- a/scripts/verify-widget-build.mjs
+++ b/scripts/verify-widget-build.mjs
@@ -1,0 +1,53 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+async function main() {
+  const widgetDir = path.join('docs', 'public', 'widgets', 'decision-tree');
+  const assetsDir = path.join(widgetDir, 'assets');
+
+  // Check assets directory exists and is not empty
+  const assets = await fs.readdir(assetsDir).catch(() => {
+    throw new Error(`Missing assets directory: ${assetsDir}`);
+  });
+  if (assets.length === 0) {
+    throw new Error(`No assets found in ${assetsDir}`);
+  }
+
+  // Check index.html exists
+  const indexPath = path.join(widgetDir, 'index.html');
+  const indexHtml = await fs.readFile(indexPath, 'utf8').catch(() => {
+    throw new Error(`Missing index.html at ${indexPath}`);
+  });
+
+  // Extract asset references and ensure each exists
+  const assetRefs = [...indexHtml.matchAll(/\/(assets\/[^"'>]+)/g)].map(m => m[1]);
+
+  if (assetRefs.length === 0) {
+    console.warn('No asset references found in index.html');
+  } else {
+    console.log('Asset references found in index.html:');
+    for (const ref of assetRefs) {
+      console.log(` - ${ref}`);
+    }
+  }
+
+  for (const ref of assetRefs) {
+    const filePath = path.join(widgetDir, ref);
+    try {
+      await fs.access(filePath);
+    } catch {
+      console.error(`Referenced asset not found: ${filePath}`);
+      console.error(
+        'Possible reasons: file name typo or hash mismatch in index.html, or build configuration failed to generate this asset.'
+      );
+      throw new Error('Widget build verification failed');
+    }
+  }
+
+  console.log('Widget build verification passed');
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add build:widget script and prebuild chain
- build-widget copies dist to docs/public/widgets/decision-tree
- make docs build run after prebuild
- verify widget build assets in CI
- improve widget build verification script logging to list asset references and give hints when an asset is missing

## Testing
- `pnpm run build:widget`
- `pnpm run test:widget-build`


------
https://chatgpt.com/codex/tasks/task_e_6898d6ce50a08328bdeec5b8549eab73