### PR TITLE
fix(widget): build widget before site build and set iframe src to /widgets/decision-tree/index.html

### DIFF
--- a/decision-tree-app/build-widget.sh
+++ b/decision-tree-app/build-widget.sh
@@ -1,20 +1,11 @@
 #!/bin/bash
-
-# Build script to copy decision-tree widget output to docs/public widgets directory
 set -e
 
 DEST_DIR="../docs/public/widgets/decision-tree"
 
-# Ensure destination directories exist
-mkdir -p "$DEST_DIR/assets"
+rm -rf "$DEST_DIR"
+mkdir -p "$DEST_DIR"
 
-# Replace existing assets with new build
-rm -f "$DEST_DIR/assets"/*
-cp dist/assets/* "$DEST_DIR/assets/"
-cp dist/index.html "$DEST_DIR/index.html"
+cp -R dist/* "$DEST_DIR/"
 
-# Update HTML references with new hashed filenames
-node ../scripts/update-html-hashes.js dist "$DEST_DIR/index.html"
-
-echo "✅ build completed and files copied to $DEST_DIR"
-
+echo "✅ widget built and copied to $DEST_DIR"

--- a/decision-tree-app/vite.config.js
+++ b/decision-tree-app/vite.config.js
@@ -4,7 +4,7 @@ import markdown from 'vite-plugin-md';
 
 export default defineConfig({
   plugins: [react(), markdown()],
-  base: '/',
+  base: './',
   build: {
     outDir: 'dist',
     assetsDir: 'assets',

--- a/docs/index.html
+++ b/docs/index.html
@@ -22,8 +22,6 @@
   <link rel="icon" href="/images/favicon.ico" />
   <link rel="stylesheet" href="assets/css/site-a4c0b310.css" />
   <!-- استایل اصلی سفارشی سایت -->
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Vazirmatn:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/css/header-awatt.css">
   <script type="module" src="/js/header-awatt.js"></script>
 </head>
@@ -128,7 +126,7 @@
     <h2 class="text-center text-2xl font-bold mb-6">درخت تصمیم‌گیری</h2>
     <iframe
       id="decision-tree-widget"
-      src="widget/index.html"
+      src="/widgets/decision-tree/index.html"
       loading="lazy"
       style="width:100%;min-height:650px;border:none"
       title="Decision Tree Widget">

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -1,0 +1,2 @@
+/widget/*   /widgets/decision-tree/:splat   301
+

--- a/docs/public/widgets/decision-tree/index.html
+++ b/docs/public/widgets/decision-tree/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Decision Tree App</title>
+<meta http-equiv="Strict-Transport-Security" content="max-age=63072000; includeSubDomains; preload" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'" />
+<meta http-equiv="X-Content-Type-Options" content="nosniff" />
+<meta http-equiv="Referrer-Policy" content="same-origin" />
+    <script type="module" crossorigin src="./assets/index-Bv_zMHHp.js"></script>
+    <link rel="stylesheet" crossorigin href="./assets/index-BMevpVvu.css">
+  </head>
+  <body>
+    <div id="widget-root"></div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- build decision-tree widget and copy output to `docs/public/widgets/decision-tree` before docs build
- point home page iframe to `/widgets/decision-tree/index.html`
- keep redirect from legacy `/widget/*` path

## Testing
- `pnpm install`
- `pnpm run build`
- `ls -la docs/dist/widgets/decision-tree/`
- `head -n 20 docs/dist/widgets/decision-tree/index.html`
- `grep -R "fonts.googleapis.com\|fonts.gstatic.com" docs/dist || echo "OK: no external fonts"`


------
https://chatgpt.com/codex/tasks/task_e_6899686bf8888328a832fccf6b31615c