### PR TITLE
feat: integrate decision tree widget build

### DIFF
--- a/decision-tree-app/package.json
+++ b/decision-tree-app/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite --host",
     "build": "vite build",
-    "build-widget": "vite build && bash ./build-widget.sh",
+    "build-widget": "vite build && mkdir -p ../docs/public/widgets/decision-tree && cp -r dist/* ../docs/public/widgets/decision-tree/",
     "lint": "eslint \"**/*.{js,jsx,ts,tsx}\" --max-warnings=0",
     "preview": "vite preview --host"
   },

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   },
   "scripts": {
     "build:widget": "pnpm --filter decision-tree-app run build-widget",
-    "prebuild": "pnpm run build:widget && pnpm node scripts/sync-images.mjs && pnpm node scripts/generate-posts.mjs && pnpm node scripts/generate-articles.mjs && pnpm node scripts/minify-articles.mjs",
-    "build": "pnpm run prebuild && pnpm -C docs run build",
+    "prebuild": "pnpm node scripts/sync-images.mjs && pnpm node scripts/generate-posts.mjs && pnpm node scripts/generate-articles.mjs && pnpm node scripts/minify-articles.mjs",
+    "build": "pnpm run build:widget && pnpm run prebuild && pnpm -C docs run build",
     "test:widget-build": "node scripts/verify-widget-build.mjs"
   }
 }


### PR DESCRIPTION
## Summary
- build decision tree widget directly into docs/public/widgets/decision-tree
- ensure root build script generates widget before building docs site

## Testing
- `pnpm run build:widget`
- `pnpm run test:widget-build`


------
https://chatgpt.com/codex/tasks/task_e_68997d7d99148328824af3bbd9bd2d66