### PR TITLE
fix(widget-build): run build-widget before site build in cf-build.sh

### DIFF
--- a/scripts/cf-build.sh
+++ b/scripts/cf-build.sh
@@ -23,18 +23,10 @@ node -v || true
 # رفع هشدار/ایراد lockfile ناسازگار: اجازه بده نصب انجام بشه حتی اگر نسخه‌ی pnpm فرق داره
 echo "==> Installing root deps (if any)"
 pnpm install --frozen-lockfile=false || true
-
-echo "==> Running prebuild scripts from repo root"
-# از Node ریشه صدا بزن که مسیرها درست باشه
-pnpm node scripts/sync-images.mjs
-pnpm node scripts/generate-posts.mjs
-pnpm node scripts/generate-articles.mjs
-pnpm node scripts/minify-articles.mjs
-
 echo "==> Installing docs deps"
 pnpm -C docs install --frozen-lockfile=false
 
-echo "==> Building Vite (docs)"
-pnpm -C docs run build
+echo "==> Running full build (widget + site)"
+pnpm run build
 
 echo "==> Build finished. Output at docs/dist"


### PR DESCRIPTION
## Summary
- run site build via `pnpm run build` so widget assets are generated before Vite build

## Testing
- `pnpm run build`
- `ls -la docs/dist/widgets/decision-tree/`
- `ls -la docs/dist/widgets/decision-tree/assets/ | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68997da41d1883288f9e1e5242b4c086